### PR TITLE
Paintroid 514 : Zoom level and position should be reset when creating a new image

### DIFF
--- a/lib/ui/io_handler.dart
+++ b/lib/ui/io_handler.dart
@@ -81,7 +81,8 @@ class IOHandler {
     if (!shouldContinue) return false;
     ref.read(CanvasState.provider.notifier)
       ..clearBackgroundImageAndResetDimensions()
-      ..resetCanvasWithNewCommands([]);
+      ..resetCanvasWithNewCommands([])
+      ..resetCanvasScaleCallback.call();
     ref.read(WorkspaceState.provider.notifier).updateLastSavedCommandCount();
     return true;
   }

--- a/lib/workspace/src/state/canvas_state_notifier.dart
+++ b/lib/workspace/src/state/canvas_state_notifier.dart
@@ -16,6 +16,10 @@ class CanvasStateNotifier extends StateNotifier<CanvasState> {
 
   final CommandManager _commandManager;
   final GraphicFactory _graphicFactory;
+  late VoidCallback resetCanvasScaleCallback;
+
+  void setResetCanvasScaleCallback(VoidCallback callback) =>
+      resetCanvasScaleCallback = callback;
 
   void setBackgroundImage(Image image) => state = state.copyWith(
         backgroundImage: Option.some(image),

--- a/lib/workspace/src/ui/drawing_canvas.dart
+++ b/lib/workspace/src/ui/drawing_canvas.dart
@@ -96,6 +96,9 @@ class _DrawingCanvasState extends ConsumerState<DrawingCanvas> {
   void initState() {
     super.initState();
     _resetCanvasScale();
+    ref
+        .read(CanvasState.provider.notifier)
+        .setResetCanvasScaleCallback(_resetCanvasScale);
   }
 
   @override


### PR DESCRIPTION
[PAINTROID-553](https://jira.catrob.at/browse/PAINTROID-553)

Added a callback to CanvasStateNotifier and used it to call _resetCanvasScale in newImage.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

[PAINTROID-553]: https://catrobat.atlassian.net/browse/PAINTROID-553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ