### PR TITLE
PAINTROID-553 : Saving two projects with the same name and deleting one of them causes a red screen

### DIFF
--- a/lib/data/project_dao.dart
+++ b/lib/data/project_dao.dart
@@ -17,4 +17,7 @@ abstract class ProjectDAO {
 
   @Query('SELECT * FROM Project order by lastModified desc')
   Future<List<Project>> getProjects();
+
+  @Query('SELECT * FROM Project WHERE name = :name')
+  Future<Project?> getProjectByName(String name);
 }

--- a/lib/io/src/failure/save_image_failure.dart
+++ b/lib/io/src/failure/save_image_failure.dart
@@ -8,4 +8,5 @@ class SaveImageFailure extends Failure {
   static const userCancelled =
       SaveImageFailure._('User did not choose a save location');
   static const unidentified = SaveImageFailure._('Could not save image');
+  static const deletionFailed = SaveImageFailure._('Could not delete image');
 }

--- a/lib/io/src/service/file_service.dart
+++ b/lib/io/src/service/file_service.dart
@@ -20,6 +20,11 @@ abstract class IFileService {
   Result<File, Failure> getFile(String path);
 
   static final provider = Provider<IFileService>((ref) => FileService());
+
+  Future<bool> checkIfFileExistsInApplicationDirectory(String fileName);
+
+  Future<Result<FileSystemEntity, Failure>> deleteFileInApplicationDirectory(
+      String fileName);
 }
 
 class FileService with LoggableMixin implements IFileService {
@@ -61,6 +66,24 @@ class FileService with LoggableMixin implements IFileService {
   Future<String> get _localPath async {
     final directory = await getApplicationDocumentsDirectory();
     return directory.path;
+  }
+
+  @override
+  Future<bool> checkIfFileExistsInApplicationDirectory(String fileName) async {
+    String saveDirectory = '${await _localPath}/$fileName';
+    return File(saveDirectory).exists();
+  }
+
+  @override
+  Future<Result<FileSystemEntity, Failure>> deleteFileInApplicationDirectory(
+      String fileName) async {
+    try {
+      String saveDirectory = '${await _localPath}/$fileName';
+      return Result.ok(await File(saveDirectory).delete());
+    } catch (err, stacktrace) {
+      logger.severe('Could not delete file', err, stacktrace);
+      return const Result.err(SaveImageFailure.deletionFailed);
+    }
   }
 
   @override

--- a/lib/io/src/ui/overwrite_dialog.dart
+++ b/lib/io/src/ui/overwrite_dialog.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:paintroid/io/src/ui/generic_dialog.dart';
+
+Future<bool?> showOverwriteDialog(BuildContext context) =>
+    showGeneralDialog<bool>(
+      context: context,
+      pageBuilder: (_, __, ___) => GenericDialog(
+        title: 'Overwrite',
+        text: 'Are you sure you want to overwrite the existing'
+            ' file?\n\nThis action cannot be undone.',
+        actions: [
+          GenericDialogAction(
+            title: 'Cancel',
+            onPressed: () => Navigator.of(context).pop(true),
+          ),
+          GenericDialogAction(
+            title: 'Yes',
+            onPressed: () => Navigator.of(context).pop(false),
+          ),
+        ],
+      ),
+      barrierDismissible: true,
+      barrierLabel: 'Show overwrite dialog',
+    );

--- a/lib/ui/shared/overflow_menu.dart
+++ b/lib/ui/shared/overflow_menu.dart
@@ -1,10 +1,13 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+import 'package:oxidized/oxidized.dart';
 import 'package:paintroid/core/app_localizations.dart';
 import 'package:paintroid/data/model/project.dart';
 import 'package:paintroid/data/project_database.dart';
+import 'package:paintroid/io/src/entity/image_meta_data.dart';
+import 'package:paintroid/io/src/service/file_service.dart';
+import 'package:paintroid/io/src/ui/overwrite_dialog.dart';
 import 'package:paintroid/io/src/ui/save_image_dialog.dart';
 import 'package:paintroid/ui/io_handler.dart';
 import 'package:paintroid/ui/pop_menu_button.dart';
@@ -84,27 +87,83 @@ class _OverflowMenuState extends ConsumerState<OverflowMenu> {
   void _enterFullscreen() =>
       ref.read(WorkspaceState.provider.notifier).toggleFullscreen(true);
 
+  Future<bool> _showOverwriteDialog() async {
+    return await showOverwriteDialog(context) ?? false;
+  }
+
+  Future<bool> _deleteFileAndAssociatedProject(CatrobatImageMetaData imageData,
+      ProjectDatabase db, IFileService fileService) async {
+    final fileName = '${imageData.name}.${imageData.format.extension}';
+
+    final result = await fileService.deleteFileInApplicationDirectory(fileName);
+    if (result is Err) {
+      Fluttertoast.showToast(
+        msg: 'Could not delete the file while overwriting!',
+      );
+      return false;
+    }
+
+    final oldProject = await db.projectDAO.getProjectByName(imageData.name);
+    final oldProjectId = oldProject?.id;
+    if (oldProject != null && oldProjectId != null) {
+      await db.projectDAO.deleteProject(oldProjectId);
+      ref.invalidate(ProjectDatabase.provider);
+    }
+
+    return true;
+  }
+
+  Future<bool> _checkIfFileExistsAndConfirmOverwrite(
+      CatrobatImageMetaData imageData, ProjectDatabase db) async {
+    final fileService = ref.watch(IFileService.provider);
+    final fileName = '${imageData.name}.${imageData.format.extension}';
+    final fileExists =
+        await fileService.checkIfFileExistsInApplicationDirectory(fileName);
+
+    if (fileExists) {
+      final overWriteCanceled = await _showOverwriteDialog();
+      if (overWriteCanceled) {
+        Fluttertoast.showToast(msg: 'Project not saved!');
+        return false;
+      }
+      return await _deleteFileAndAssociatedProject(imageData, db, fileService);
+    }
+
+    return true;
+  }
+
   Future<void> _saveProject() async {
-    File? savedProject;
     final imageData = await showSaveImageDialog(context, true);
 
-    if (imageData != null && mounted) {
-      savedProject = await ioHandler.saveProject(imageData);
+    if (imageData == null) {
+      return;
+    }
+
+    final catrobatImageData = imageData as CatrobatImageMetaData;
+
+    final db = await ref.read(ProjectDatabase.provider.future);
+
+    if (!await _checkIfFileExistsAndConfirmOverwrite(catrobatImageData, db)) {
+      return;
+    }
+
+    if (mounted) {
+      final savedProject = await ioHandler.saveProject(catrobatImageData);
       if (savedProject != null) {
-        String? imagePreview = await ioHandler.getPreviewPath(imageData);
-        Project project = Project(
-          name: imageData.name,
+        String? imagePreview =
+            await ioHandler.getPreviewPath(catrobatImageData);
+        Project projectNew = Project(
+          name: catrobatImageData.name,
           path: savedProject.path,
           lastModified: DateTime.now(),
           creationDate: DateTime.now(),
           resolution: '',
-          format: imageData.format.name,
+          format: catrobatImageData.format.name,
           size: await savedProject.length(),
           imagePreviewPath: imagePreview,
         );
 
-        final db = await ref.read(ProjectDatabase.provider.future);
-        await db.projectDAO.insertProject(project);
+        await db.projectDAO.insertProject(projectNew);
       }
     }
   }

--- a/test/unit/io/service/file_service_test.dart
+++ b/test/unit/io/service/file_service_test.dart
@@ -42,4 +42,40 @@ void main() async {
     final file = result.unwrapOrElse((failure) => fail(failure.message));
     expect(file, isA<File>());
   });
+
+  test('Should save file to Application directory and delete it', () async {
+    final result = await sut.saveToApplicationDirectory(
+      'test1.png',
+      testPngFile.buffer.asUint8List(),
+    );
+    final file = result.unwrapOrElse((failure) => fail(failure.message));
+    expect(file, isA<File>());
+
+    final resultDeleted = await sut.deleteFileInApplicationDirectory(
+      'test1.png'
+    );
+    final deleted = resultDeleted.unwrapOrElse((failure) => fail(failure.message));
+    expect(deleted, isA<FileSystemEntity>());
+  });
+
+  test('Should save file to Application directory and check should return true', () async {
+    final fileDoesNotExist = await sut.checkIfFileExistsInApplicationDirectory(
+        'test1.png'
+    );
+
+    expect(fileDoesNotExist, false);
+
+    final result = await sut.saveToApplicationDirectory(
+      'test1.png',
+      testPngFile.buffer.asUint8List(),
+    );
+    final file = result.unwrapOrElse((failure) => fail(failure.message));
+    expect(file, isA<File>());
+
+    final fileExists = await sut.checkIfFileExistsInApplicationDirectory(
+        'test1.png'
+    );
+
+    expect(fileExists, true);
+  });
 }


### PR DESCRIPTION
[PAINTROID-553](https://jira.catrob.at/browse/PAINTROID-553)

The issue was that saveToApplicationDirectory overwrote the data and a new project got created in the database. Deleting one project would delete the overwritten file and the other projects in the database pointed at the wrong filepath.

Added a new DAO function  that retrieves project by name for easier use in code.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer