### PR TITLE
PAINTROID-453 : Flutter: Add Brush Options

### DIFF
--- a/lib/tool/src/brush_paint.dart
+++ b/lib/tool/src/brush_paint.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:paintroid/core/graphic_factory.dart';
+import 'package:paintroid/tool/src/brush_paint_notifier.dart';
+
+@immutable
+class BrushPaintState {
+  const BrushPaintState({required this.paint});
+
+  final Paint paint;
+
+  static final provider =
+      StateNotifierProvider<BrushPaintNotifier, BrushPaintState>(
+    (ref) => BrushPaintNotifier(
+      BrushPaintState(
+        paint: ref.watch(GraphicFactory.provider).createPaint()
+          ..style = PaintingStyle.stroke
+          ..strokeJoin = StrokeJoin.round
+          ..color = const Color(0xFF830000)
+          ..strokeCap = StrokeCap.round
+          ..strokeWidth = 25,
+      ),
+    ),
+  );
+
+  BrushPaintState copyWith({Paint? paint}) {
+    return BrushPaintState(paint: paint ?? this.paint);
+  }
+}

--- a/lib/tool/src/brush_paint_notifier.dart
+++ b/lib/tool/src/brush_paint_notifier.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/painting.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:paintroid/tool/src/brush_paint.dart';
+
+class BrushPaintNotifier extends StateNotifier<BrushPaintState> {
+  BrushPaintNotifier(super.state);
+
+  void updateStrokeWidth(double newStrokeWidth) {
+    Paint newPaint = state.paint..strokeWidth = newStrokeWidth;
+    state = state.copyWith(paint: newPaint);
+  }
+
+  void updateStrokeCap(StrokeCap newStrokeCap) {
+    Paint newPaint = state.paint..strokeCap = newStrokeCap;
+    state = state.copyWith(paint: newPaint);
+  }
+
+  void updateColor(Color newColor) {
+    Paint newPaint = state.paint..color = newColor;
+    state = state.copyWith(paint: newPaint);
+  }
+}

--- a/lib/tool/src/brush_tool.dart
+++ b/lib/tool/src/brush_tool.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:paintroid/command/command.dart';
 import 'package:paintroid/core/graphic_factory.dart';
 import 'package:paintroid/core/path_with_action_history.dart';
+import 'package:paintroid/tool/src/brush_paint.dart';
 import 'package:paintroid/tool/src/tool.dart';
 
 class BrushTool extends Tool with EquatableMixin {
@@ -18,11 +19,7 @@ class BrushTool extends Tool with EquatableMixin {
 
   static final provider = Provider(
     (ref) => BrushTool(
-      paint: ref.watch(GraphicFactory.provider).createPaint()
-        ..style = PaintingStyle.stroke
-        ..color = const Color(0xFF808080)
-        ..strokeCap = StrokeCap.round
-        ..strokeWidth = 25,
+      paint: ref.watch(BrushPaintState.provider).paint,
       commandManager: ref.watch(CommandManager.provider),
       commandFactory: ref.watch(CommandFactory.provider),
       graphicFactory: ref.watch(GraphicFactory.provider),
@@ -61,4 +58,17 @@ class BrushTool extends Tool with EquatableMixin {
 
   @override
   List<Object?> get props => [commandManager, commandFactory, graphicFactory];
+
+  BrushTool copyWith(
+      {Paint? paint,
+      CommandFactory? commandFactory,
+      CommandManager? commandManager,
+      GraphicFactory? graphicFactory}) {
+    return BrushTool(
+      paint: paint ?? this.paint,
+      commandFactory: commandFactory ?? this.commandFactory,
+      commandManager: commandManager ?? this.commandManager,
+      graphicFactory: graphicFactory ?? this.graphicFactory,
+    );
+  }
 }

--- a/lib/ui/drawing_space/bottom_brush_tool_options.dart
+++ b/lib/ui/drawing_space/bottom_brush_tool_options.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:paintroid/tool/src/brush_paint.dart';
+import 'package:paintroid/ui/shared/custom_action_chip.dart';
+
+class BottomBrushToolOptions extends ConsumerStatefulWidget {
+  const BottomBrushToolOptions({super.key});
+
+  @override
+  ConsumerState<BottomBrushToolOptions> createState() =>
+      _BottomBrushToolOptionsState();
+}
+
+class _BottomBrushToolOptionsState
+    extends ConsumerState<BottomBrushToolOptions> {
+  Color _roundChipBackgroundColor = Colors.blue;
+  Color _squareChipBackgroundColor = Colors.white;
+
+  void _changeActionChipBackgroundColor(StrokeCap strokeCap) {
+    _roundChipBackgroundColor =
+        strokeCap == StrokeCap.round ? Colors.blue : Colors.white;
+    _squareChipBackgroundColor =
+        strokeCap == StrokeCap.square ? Colors.blue : Colors.white;
+    ref.read(BrushPaintState.provider.notifier).updateStrokeCap(strokeCap);
+  }
+
+  BorderRadius _getToolPreviewBorderRadius(
+      StrokeCap strokeCap, double toolStrokeWidth) {
+    if (strokeCap == StrokeCap.round) {
+      return BorderRadius.horizontal(
+        left: Radius.circular(toolStrokeWidth),
+        right: Radius.circular(toolStrokeWidth),
+      );
+    } else {
+      return const BorderRadius.horizontal();
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    StrokeCap toolStrokeCapOnInit =
+        ref.read(BrushPaintState.provider).paint.strokeCap;
+    _roundChipBackgroundColor =
+        toolStrokeCapOnInit == StrokeCap.round ? Colors.blue : Colors.white;
+    _squareChipBackgroundColor =
+        toolStrokeCapOnInit == StrokeCap.square ? Colors.blue : Colors.white;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final currentPaint = ref.watch(BrushPaintState.provider).paint;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        Wrap(
+          spacing: 8,
+          children: [
+            CustomActionChip(
+              chipIcon: const Icon(Icons.circle),
+              onPressed: () =>
+                  _changeActionChipBackgroundColor(StrokeCap.round),
+              chipBackgroundColor: _roundChipBackgroundColor,
+            ),
+            CustomActionChip(
+              chipIcon: const Icon(Icons.square),
+              onPressed: () =>
+                  _changeActionChipBackgroundColor(StrokeCap.square),
+              chipBackgroundColor: _squareChipBackgroundColor,
+            ),
+          ],
+        ),
+        const Spacer(),
+        Container(
+          height: currentPaint.strokeWidth * 0.4,
+          width: 130,
+          decoration: BoxDecoration(
+            color: currentPaint.color,
+            borderRadius: _getToolPreviewBorderRadius(
+              currentPaint.strokeCap,
+              currentPaint.strokeWidth,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/drawing_space/tool_options.dart
+++ b/lib/ui/drawing_space/tool_options.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:paintroid/ui/drawing_space/bottom_brush_tool_options.dart';
+import 'package:paintroid/ui/drawing_space/top_brush_tool_options.dart';
+
+class ToolOptions extends StatelessWidget {
+  const ToolOptions({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.all(8),
+      child: Column(
+        children: [
+          TopBrushToolOptions(),
+          Spacer(),
+          BottomBrushToolOptions(),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/drawing_space/top_brush_tool_options.dart
+++ b/lib/ui/drawing_space/top_brush_tool_options.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:paintroid/tool/src/brush_paint.dart';
+import 'package:paintroid/ui/styles.dart';
+
+class TopBrushToolOptions extends ConsumerStatefulWidget {
+  const TopBrushToolOptions({super.key});
+
+  @override
+  ConsumerState<TopBrushToolOptions> createState() => _NumberTextFieldState();
+}
+
+class _NumberTextFieldState extends ConsumerState<TopBrushToolOptions> {
+  late final TextEditingController _strokeWidthTextController;
+
+  void _onChangedTextField(String value) {
+    final newStrokeWidth = int.tryParse(value) ?? 1;
+    ref
+        .read(BrushPaintState.provider.notifier)
+        .updateStrokeWidth(newStrokeWidth.toDouble());
+  }
+
+  void _onChangedSlider(double newValue) {
+    _strokeWidthTextController.text = newValue.toInt().toString();
+    ref.read(BrushPaintState.provider.notifier).updateStrokeWidth(newValue);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _strokeWidthTextController = TextEditingController(
+      text: ref
+          .read(BrushPaintState.provider)
+          .paint
+          .strokeWidth
+          .toInt()
+          .toString(),
+    );
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _strokeWidthTextController.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final strokeWidth = ref.watch(BrushPaintState.provider).paint.strokeWidth;
+
+    return SizedBox(
+      height: 25,
+      child: Row(
+        children: [
+          Expanded(
+            flex: 1,
+            child: TextField(
+              controller: _strokeWidthTextController,
+              style: ThemeText.menuItem,
+              textAlign: TextAlign.center,
+              keyboardType: TextInputType.number,
+              inputFormatters: [
+                FilteringTextInputFormatter.allow(
+                  RegExp(r'^(100|[1-9][0-9]?)$'),
+                  replacementString: strokeWidth.toInt().toString(),
+                ),
+              ],
+              onChanged: _onChangedTextField,
+              decoration: InputDecoration(
+                filled: true,
+                fillColor: Colors.white,
+                contentPadding: EdgeInsets.zero,
+                hintText: '1',
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: BorderSide.none,
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            flex: 8,
+            child: SliderTheme(
+              data: SliderTheme.of(context).copyWith(
+                showValueIndicator: ShowValueIndicator.never,
+              ),
+              child: Slider(
+                value: strokeWidth,
+                min: 1,
+                max: 100,
+                divisions: 100,
+                label: strokeWidth.toInt().toString(),
+                onChanged: _onChangedSlider,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/pocket_paint.dart
+++ b/lib/ui/pocket_paint.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:paintroid/io/io.dart';
 import 'package:paintroid/ui/drawing_space/bottom_control_navigation_bar.dart';
 import 'package:paintroid/ui/drawing_space/exit_fullscreen_button.dart';
+import 'package:paintroid/ui/drawing_space/tool_options.dart';
 import 'package:paintroid/ui/io_handler.dart';
 import 'package:paintroid/ui/shared/top_app_bar.dart';
 import 'package:paintroid/workspace/workspace.dart';
@@ -61,7 +62,6 @@ class _PocketPaintState extends ConsumerState<PocketPaint> {
         backgroundColor: Colors.grey.shade400,
         resizeToAvoidBottomInset: true,
         body: Stack(
-          clipBehavior: Clip.hardEdge,
           children: [
             const DrawingCanvas(),
             if (isFullscreen)
@@ -69,7 +69,9 @@ class _PocketPaintState extends ConsumerState<PocketPaint> {
                 top: 2,
                 right: 2,
                 child: SafeArea(child: ExitFullscreenButton()),
-              ),
+              )
+            else
+              const ToolOptions(),
           ],
         ),
         bottomNavigationBar:

--- a/lib/ui/pop_menu_button.dart
+++ b/lib/ui/pop_menu_button.dart
@@ -2,27 +2,32 @@ import 'package:flutter/material.dart';
 
 class StyledPopMenuButton<T> extends StatelessWidget {
   final void Function(T) onSelected;
-
   final PopupMenuItemBuilder<T> itemBuilder;
 
-  const StyledPopMenuButton({super.key, required this.onSelected, required this.itemBuilder});
+  const StyledPopMenuButton({
+    super.key,
+    required this.onSelected,
+    required this.itemBuilder,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Theme(
-        data: Theme.of(context).copyWith(useMaterial3: false), // disable for shadow to work
-        child: PopupMenuButton<T>(
+      data: Theme.of(context).copyWith(useMaterial3: false),
+      child: PopupMenuButton<T>(
+        color: Theme.of(context).colorScheme.background,
+        icon: const Icon(Icons.more_vert, color: Colors.white),
+        elevation: 7.0,
+        shape: RoundedRectangleBorder(
+          side: BorderSide(
+            width: 0,
             color: Theme.of(context).colorScheme.background,
-            icon: const Icon(
-              Icons.more_vert,
-              color: Colors.white,
-            ),
-            elevation: 7.0,
-            shape: RoundedRectangleBorder(
-              side: BorderSide(width: 0, color: Theme.of(context).colorScheme.background),
-              borderRadius: BorderRadius.circular(5),
-            ),
-            onSelected: onSelected,
-            itemBuilder: itemBuilder));
+          ),
+          borderRadius: BorderRadius.circular(5),
+        ),
+        onSelected: onSelected,
+        itemBuilder: itemBuilder,
+      ),
+    );
   }
 }

--- a/lib/ui/shared/custom_action_chip.dart
+++ b/lib/ui/shared/custom_action_chip.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+class CustomActionChip extends StatelessWidget {
+  final Icon chipIcon;
+  final VoidCallback onPressed;
+  final OutlinedBorder? shape;
+  final Color chipBackgroundColor;
+  final EdgeInsetsGeometry? padding;
+  final MaterialTapTargetSize? materialTapTargetSize;
+
+  const CustomActionChip({
+    super.key,
+    required this.chipIcon,
+    required this.onPressed,
+    required this.chipBackgroundColor,
+    this.shape,
+    this.padding,
+    this.materialTapTargetSize,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ActionChip(
+      label: chipIcon,
+      onPressed: onPressed,
+      shape: shape ??
+          const RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(20)),
+          ),
+      backgroundColor: chipBackgroundColor,
+      padding: padding ?? const EdgeInsets.fromLTRB(8, 0, 8, 0),
+      materialTapTargetSize:
+          materialTapTargetSize ?? MaterialTapTargetSize.shrinkWrap,
+    );
+  }
+}


### PR DESCRIPTION
[PAINTROID-453](https://jira.catrob.at/browse/PAINTROID-453)

Added top and bottom brush tool options. Added a new provider for brush tool paint properties.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
