### PR TITLE
PAINTROID-635 : Checkerboard is not the same density as Kotlin version

### DIFF
--- a/lib/workspace/src/ui/checkerboard_pattern.dart
+++ b/lib/workspace/src/ui/checkerboard_pattern.dart
@@ -13,8 +13,8 @@ class CheckerboardPattern extends StatelessWidget {
           child: Image.asset(
             'assets/img/checkerboard.png',
             repeat: ImageRepeat.repeat,
-            cacheWidth: 80,
-            cacheHeight: 80,
+            cacheWidth: 50,
+            cacheHeight: 50,
             filterQuality: FilterQuality.none,
           ),
         ),


### PR DESCRIPTION
[PAINTROID-635](https://jira.catrob.at/browse/PAINTROID-635)

Changed checkerboard tile density & tried to match with kotlin version as good as possible.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
