### PR TITLE
PAINTROID-654 : Remove tests from exluded folders and fix issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,11 +11,13 @@ jobs:
         uses: arduino/setup-protoc@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: subosito/flutter-action@v2.5.0
+      - uses: subosito/flutter-action@v2.10.0
         with:
           flutter-version: '3.10.5'
           channel: 'stable'
-          cache: true
+          cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
+          cache-path: '${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:'
+          architecture: x64 # optional, x64 or arm64
       - name: Setup
         run: |
           flutter pub get

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -22,4 +22,3 @@ analyzer:
   exclude:
     - lib/**.pb*.dart
     - lib/data/*.g.dart
-    - test/**

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -241,6 +241,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  device_info_plus:
+    dependency: "direct main"
+    description:
+      name: device_info_plus
+      sha256: "86add5ef97215562d2e090535b0a16f197902b10c369c558a100e74ea06e8659"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.3"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      sha256: d3b01d5868b50ae571cd1dc6e502fc94d956b665756180f7b16ead09e836fd64
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   equatable:
     dependency: "direct main"
     description:
@@ -837,7 +853,7 @@ packages:
     source: hosted
     version: "1.2.3"
   riverpod:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: riverpod
       sha256: "80e48bebc83010d5e67a11c9514af6b44bbac1ec77b4333c8ea65dbc79e2d8ef"
@@ -1257,6 +1273,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.4"
+  win32_registry:
+    dependency: transitive
+    description:
+      name: win32_registry
+      sha256: "1c52f994bdccb77103a6231ad4ea331a244dbcef5d1f37d8462f713143b0bfae"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dev_dependencies:
   riverpod_generator: ^2.2.3
   riverpod_lint: ^1.3.2
   freezed: ^2.4.1
+  riverpod: ^2.3.7
 
 flutter:
   generate: true

--- a/test/unit/io/service/file_service_test.dart
+++ b/test/unit/io/service/file_service_test.dart
@@ -15,8 +15,10 @@ void main() async {
   const channel = MethodChannel(
     'plugins.flutter.io/path_provider',
   );
-  channel
-      .setMockMethodCallHandler((MethodCall methodCall) async => testDirectory);
+  final defaultBinaryMessenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+  defaultBinaryMessenger.setMockMethodCallHandler(
+      channel, (MethodCall methodCall) async => testDirectory);
 
   setUp(() async {
     sut = FileService();
@@ -51,17 +53,17 @@ void main() async {
     final file = result.unwrapOrElse((failure) => fail(failure.message));
     expect(file, isA<File>());
 
-    final resultDeleted = await sut.deleteFileInApplicationDirectory(
-      'test1.png'
-    );
-    final deleted = resultDeleted.unwrapOrElse((failure) => fail(failure.message));
+    final resultDeleted =
+        await sut.deleteFileInApplicationDirectory('test1.png');
+    final deleted =
+        resultDeleted.unwrapOrElse((failure) => fail(failure.message));
     expect(deleted, isA<FileSystemEntity>());
   });
 
-  test('Should save file to Application directory and check should return true', () async {
-    final fileDoesNotExist = await sut.checkIfFileExistsInApplicationDirectory(
-        'test1.png'
-    );
+  test('Should save file to Application directory and check should return true',
+      () async {
+    final fileDoesNotExist =
+        await sut.checkIfFileExistsInApplicationDirectory('test1.png');
 
     expect(fileDoesNotExist, false);
 
@@ -72,9 +74,8 @@ void main() async {
     final file = result.unwrapOrElse((failure) => fail(failure.message));
     expect(file, isA<File>());
 
-    final fileExists = await sut.checkIfFileExistsInApplicationDirectory(
-        'test1.png'
-    );
+    final fileExists =
+        await sut.checkIfFileExistsInApplicationDirectory('test1.png');
 
     expect(fileExists, true);
   });

--- a/test/unit/io/service/photo_library_service_test.dart
+++ b/test/unit/io/service/photo_library_service_test.dart
@@ -50,7 +50,7 @@ void main() {
           'data': testImageData,
         };
         final result = await sut.save(testFilename, testImageData);
-        expect(result, Ok<Unit, Failure>(unit));
+        expect(result, const Ok<Unit, Failure>(unit));
         verify(mockMethodChannel.invokeMethod('saveToPhotos', expectedArgs));
         verifyNoMoreInteractions(mockMethodChannel);
         verifyZeroInteractions(mockImagePicker);
@@ -62,7 +62,7 @@ void main() {
       () async {
         when(mockMethodChannel.invokeMethod(any, any)).thenThrow(testException);
         final result = await sut.save(testFilename, testImageData);
-        expect(result, Err<Unit, Failure>(SaveImageFailure.unidentified));
+        expect(result, const Err<Unit, Failure>(SaveImageFailure.unidentified));
         verify(mockMethodChannel.invokeMethod(any, any));
         verifyNoMoreInteractions(mockMethodChannel);
         verifyZeroInteractions(mockImagePicker);
@@ -75,7 +75,7 @@ void main() {
         when(mockMethodChannel.invokeMethod(any, any))
             .thenThrow(testPlatformException);
         final result = await sut.save(testFilename, testImageData);
-        expect(result, Err<Unit, Failure>(SaveImageFailure.unidentified));
+        expect(result, const Err<Unit, Failure>(SaveImageFailure.unidentified));
         verify(mockMethodChannel.invokeMethod(any, any));
         verifyNoMoreInteractions(mockMethodChannel);
         verifyZeroInteractions(mockImagePicker);
@@ -108,7 +108,7 @@ void main() {
       when(mockImagePicker.pickImage(source: anyNamed('source')))
           .thenAnswer((_) async => null);
       final result = await sut.pick();
-      expect(result, Err<Uint8List, Failure>(LoadImageFailure.userCancelled));
+      expect(result, const Err<Uint8List, Failure>(LoadImageFailure.userCancelled));
       verify(mockImagePicker.pickImage(source: anyNamed('source')));
       verifyNoMoreInteractions(mockImagePicker);
       verifyZeroInteractions(mockMethodChannel);
@@ -121,7 +121,7 @@ void main() {
         when(mockImagePicker.pickImage(source: anyNamed('source')))
             .thenThrow(testException);
         final result = await sut.pick();
-        expect(result, Err<Uint8List, Failure>(LoadImageFailure.unidentified));
+        expect(result, const Err<Uint8List, Failure>(LoadImageFailure.unidentified));
         verify(mockImagePicker.pickImage(source: anyNamed('source')));
         verifyNoMoreInteractions(mockImagePicker);
         verifyZeroInteractions(mockMethodChannel);
@@ -133,7 +133,7 @@ void main() {
             .thenAnswer((_) async => mockImageXFile);
         when(mockImageXFile.readAsBytes()).thenThrow(testException);
         final result = await sut.pick();
-        expect(result, Err<Uint8List, Failure>(LoadImageFailure.unidentified));
+        expect(result, const Err<Uint8List, Failure>(LoadImageFailure.unidentified));
         verify(mockImagePicker.pickImage(source: anyNamed('source')));
         verify(mockImageXFile.readAsBytes());
         verifyNoMoreInteractions(mockImageXFile);
@@ -148,7 +148,7 @@ void main() {
         when(mockImagePicker.pickImage(source: anyNamed('source')))
             .thenThrow(testPlatformException);
         final result = await sut.pick();
-        expect(result, Err<Uint8List, Failure>(LoadImageFailure.unidentified));
+        expect(result, const Err<Uint8List, Failure>(LoadImageFailure.unidentified));
         verify(mockImagePicker.pickImage(source: anyNamed('source')));
         verifyNoMoreInteractions(mockImagePicker);
         verifyZeroInteractions(mockMethodChannel);

--- a/test/unit/io/usecase/save_as_raster_image_test.dart
+++ b/test/unit/io/usecase/save_as_raster_image_test.dart
@@ -65,10 +65,10 @@ void main() {
         when(mockImageService.exportAsPng(any))
             .thenAnswer((_) async => Ok(fakeBytes));
         when(mockPhotoLibraryService.save(any, any))
-            .thenAnswer((_) async => Ok(unit));
+            .thenAnswer((_) async => const Ok(unit));
         final testMetaData = PngMetaData(testName);
         final result = await sut(testMetaData, fakeImage);
-        expect(result, Ok<Unit, Failure>(unit));
+        expect(result, const Ok<Unit, Failure>(unit));
         verify(mockPermissionService.requestAccessForSavingToPhotos());
         verify(mockImageService.exportAsPng(fakeImage));
         verify(mockPhotoLibraryService.save(expectedFilename, fakeBytes));
@@ -84,10 +84,10 @@ void main() {
         when(mockImageService.exportAsJpg(any, any))
             .thenAnswer((_) async => Ok(fakeBytes));
         when(mockPhotoLibraryService.save(any, any))
-            .thenAnswer((_) async => Ok(unit));
+            .thenAnswer((_) async => const Ok(unit));
         final testMetaData = JpgMetaData(testName, testQuality);
         final result = await sut(testMetaData, fakeImage);
-        expect(result, Ok<Unit, Failure>(unit));
+        expect(result, const Ok<Unit, Failure>(unit));
         verify(mockPermissionService.requestAccessForSavingToPhotos());
         verify(mockImageService.exportAsJpg(fakeImage, testQuality));
         verify(mockPhotoLibraryService.save(expectedFilename, fakeBytes));
@@ -183,7 +183,7 @@ void main() {
               .thenAnswer((_) async => false);
           final testMetaData = JpgMetaData(testName, testQuality);
           final result = await sut(testMetaData, fakeImage);
-          expect(result, Err<Unit, Failure>(SaveImageFailure.permissionDenied));
+          expect(result, const Err<Unit, Failure>(SaveImageFailure.permissionDenied));
           verify(mockPermissionService.requestAccessForSavingToPhotos());
           verifyNoMoreInteractions(mockPermissionService);
           verifyZeroInteractions(mockImageService);
@@ -195,7 +195,7 @@ void main() {
               .thenAnswer((_) async => false);
           final testMetaData = PngMetaData(testName);
           final result = await sut(testMetaData, fakeImage);
-          expect(result, Err<Unit, Failure>(SaveImageFailure.permissionDenied));
+          expect(result, const Err<Unit, Failure>(SaveImageFailure.permissionDenied));
           verify(mockPermissionService.requestAccessForSavingToPhotos());
           verifyNoMoreInteractions(mockPermissionService);
           verifyZeroInteractions(mockImageService);

--- a/test/unit/tool/brush_tool_test.dart
+++ b/test/unit/tool/brush_tool_test.dart
@@ -6,7 +6,6 @@ import 'package:mockito/mockito.dart';
 import 'package:paintroid/command/command.dart';
 import 'package:paintroid/core/graphic_factory.dart';
 import 'package:paintroid/core/path_with_action_history.dart';
-import 'package:paintroid/tool/src/tool_types.dart';
 import 'package:paintroid/tool/tool.dart';
 
 import 'brush_tool_test.mocks.dart';

--- a/test/unit/workspace/usecase/render_image_for_export_test.dart
+++ b/test/unit/workspace/usecase/render_image_for_export_test.dart
@@ -89,8 +89,8 @@ class FakeGraphicCommand extends Fake implements GraphicCommand {}
 @GenerateMocks(
   [],
   customMocks: [
-    MockSpec<Canvas>(returnNullOnMissingStub: true),
-    MockSpec<CommandManager>(returnNullOnMissingStub: true),
+    MockSpec<Canvas>(),
+    MockSpec<CommandManager>(),
   ],
 )
 void main() {
@@ -145,7 +145,6 @@ void main() {
     final testCanvasRect =
         Rect.fromLTRB(0, 0, testCanvasSize.width, testCanvasSize.height);
     late Paint testPaint;
-    late Offset testOffset;
     late MockCanvas mockBackgroundCanvas;
     late MockCanvas mockCommandsCanvas;
     late MockCanvas mockCombinedCanvas;
@@ -154,7 +153,6 @@ void main() {
 
     setUp(() {
       testPaint = Paint();
-      testOffset = const Offset(0.0, 0.0);
       mockBackgroundCanvas = MockCanvas();
       mockCommandsCanvas = MockCanvas();
       mockCombinedCanvas = MockCanvas();

--- a/test/widget/ui/landing_page_test.dart
+++ b/test/widget/ui/landing_page_test.dart
@@ -39,7 +39,7 @@ void main() {
   late ui.Image dummyImage;
   final DateFormat formatter = DateFormat('dd-MM-yyyy HH:mm:ss');
 
-  Project _createProject(String name) => Project(
+  Project createProject(String name) => Project(
         name: name,
         path: filePath,
         imagePreviewPath: filePath,
@@ -62,7 +62,7 @@ void main() {
         showOnboardingPage: false,
       ),
     );
-    projects = List.generate(5, (index) => _createProject('project$index'));
+    projects = List.generate(5, (index) => createProject('project$index'));
     dummyImage = await createTestImage(width: 1080, height: 1920);
   });
 
@@ -390,7 +390,7 @@ void main() {
 
       when(database.projectDAO).thenReturn(dao);
       when(dao.getProjects())
-          .thenAnswer((_) => Future.value([_createProject(projectName)]));
+          .thenAnswer((_) => Future.value([createProject(projectName)]));
       when(fileService.checkIfFileExistsInApplicationDirectory(projectName))
           .thenAnswer((_) => Future.value(true));
       when(imageService.getProjectPreview(filePath))


### PR DESCRIPTION
[PAINTROID-654](https://jira.catrob.at/browse/PAINTROID-654)

- Removed tests from excluded folders in analysis options
- Added riverpod as dev dependency to remove warning
- Fixed analysis issues in various tests
- Fixed the deprecated warning in CI

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
