### PR TITLE
Paintroid 721 : Add PR number to the app name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,12 @@ jobs:
         run: melos run test:unit
       - name: Widget Tests
         run: melos run test:widget
+      - name: Install xmlstarlet
+        run: sudo apt-get install -y xmlstarlet
       - name: Prepare App Name and Identifier
         run: |
-          chmod +x ./update_app_identifiers.sh
-          ./update_app_identifiers.sh ${{ github.event.number }}
+          chmod +x ./.github/workflows/update_app_identifiers.sh
+          ./.github/workflows/update_app_identifiers.sh ${{ github.event.number }}
       - name: Build release package
         run: |
           flutter build apk --release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,10 @@ jobs:
         run: melos run test:unit
       - name: Widget Tests
         run: melos run test:widget
+      - name: Prepare App Name and Identifier
+        run: |
+          chmod +x ./update_app_identifiers.sh
+          ./update_app_identifiers.sh ${{ github.event.number }}
       - name: Build release package
         run: |
           flutter build apk --release

--- a/.github/workflows/update_app_identifiers.sh
+++ b/.github/workflows/update_app_identifiers.sh
@@ -5,6 +5,7 @@ PR_NUMBER=$1
 MAIN_MANIFEST="android/app/src/main/AndroidManifest.xml"
 DEBUG_MANIFEST="android/app/src/debug/AndroidManifest.xml"
 PROFILE_MANIFEST="android/app/src/profile/AndroidManifest.xml"
+BUILD_GRADLE="android/app/build.gradle"
 
 if [ -f "$MAIN_MANIFEST" ]; then
   echo "Updating $MAIN_MANIFEST with PR number $PR_NUMBER"
@@ -26,6 +27,22 @@ if [ -f "$PROFILE_MANIFEST" ]; then
   sed -i "s/package=\"org.catrobat.paintroid\"/package=\"org.catrobat.paintroid.pr$PR_NUMBER\"/" $PROFILE_MANIFEST
 else
   echo "$PROFILE_MANIFEST does not exist."
+fi
+
+if [ -f "$BUILD_GRADLE" ]; then
+  echo "Updating applicationId in $BUILD_GRADLE with PR number $PR_NUMBER"
+  sed -i "s/applicationId \"org.catrobat.paintroidflutter\"/applicationId \"org.catrobat.paintroidflutter.pr$PR_NUMBER\"/" $BUILD_GRADLE
+else
+  echo "$BUILD_GRADLE does not exist."
+fi
+
+KOTLIN_MAIN_ACTIVITY="android/app/src/main/kotlin/org/catrobat/paintroid/MainActivity.kt"
+
+if [ -f "$KOTLIN_MAIN_ACTIVITY" ]; then
+  echo "Updating MainActivity package in Kotlin with PR number $PR_NUMBER"
+  sed -i "s/package org.catrobat.paintroid/package org.catrobat.paintroid.pr$PR_NUMBER/" $KOTLIN_MAIN_ACTIVITY
+else
+  echo "MainActivity Kotlin file does not exist."
 fi
 
 INFO_PLIST="ios/Runner/Info.plist"

--- a/.github/workflows/update_app_identifiers.sh
+++ b/.github/workflows/update_app_identifiers.sh
@@ -1,0 +1,10 @@
+PR_NUMBER=$1
+
+
+ANDROID_MANIFEST="android/app/src/main/AndroidManifest.xml"
+sed -i "s/android:label=\"Pocket Paint\"/android:label=\"Pocket Paint PR$PR_NUMBER\"/" $ANDROID_MANIFEST
+sed -i "s/package=\"org.catrobat.paintroid\"/package=\"org.catrobat.paintroid.pr$PR_NUMBER\"/" $ANDROID_MANIFEST
+
+INFO_PLIST="ios/Runner/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleName paintroid PR$PR_NUMBER" $INFO_PLIST
+/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier org.catrobat.paintroidflutter.pr$PR_NUMBER" $INFO_PLIST

--- a/.github/workflows/update_app_identifiers.sh
+++ b/.github/workflows/update_app_identifiers.sh
@@ -1,10 +1,10 @@
-PR_NUMBER=$1
 
+PR_NUMBER=$1
 
 ANDROID_MANIFEST="android/app/src/main/AndroidManifest.xml"
 sed -i "s/android:label=\"Pocket Paint\"/android:label=\"Pocket Paint PR$PR_NUMBER\"/" $ANDROID_MANIFEST
 sed -i "s/package=\"org.catrobat.paintroid\"/package=\"org.catrobat.paintroid.pr$PR_NUMBER\"/" $ANDROID_MANIFEST
 
 INFO_PLIST="ios/Runner/Info.plist"
-/usr/libexec/PlistBuddy -c "Set :CFBundleName paintroid PR$PR_NUMBER" $INFO_PLIST
-/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier org.catrobat.paintroidflutter.pr$PR_NUMBER" $INFO_PLIST
+xmlstarlet ed -L -u "/plist/dict/key[text()='CFBundleName']/following-sibling::string[1]" -v "paintroid PR$PR_NUMBER" $INFO_PLIST
+xmlstarlet ed -L -u "/plist/dict/key[text()='CFBundleIdentifier']/following-sibling::string[1]" -v "org.catrobat.paintroidflutter.pr$PR_NUMBER" $INFO_PLIST

--- a/.github/workflows/update_app_identifiers.sh
+++ b/.github/workflows/update_app_identifiers.sh
@@ -1,10 +1,43 @@
+#!/bin/bash
 
 PR_NUMBER=$1
 
-ANDROID_MANIFEST="android/app/src/main/AndroidManifest.xml"
-sed -i "s/android:label=\"Pocket Paint\"/android:label=\"Pocket Paint PR$PR_NUMBER\"/" $ANDROID_MANIFEST
-sed -i "s/package=\"org.catrobat.paintroid\"/package=\"org.catrobat.paintroid.pr$PR_NUMBER\"/" $ANDROID_MANIFEST
+MAIN_MANIFEST="android/app/src/main/AndroidManifest.xml"
+DEBUG_MANIFEST="android/app/src/debug/AndroidManifest.xml"
+PROFILE_MANIFEST="android/app/src/profile/AndroidManifest.xml"
+
+if [ -f "$MAIN_MANIFEST" ]; then
+  echo "Updating $MAIN_MANIFEST with PR number $PR_NUMBER"
+  sed -i "s/package=\"org.catrobat.paintroid\"/package=\"org.catrobat.paintroid.pr$PR_NUMBER\"/" $MAIN_MANIFEST
+  sed -i "s/android:label=\"Pocket Paint\"/android:label=\"Pocket Paint PR$PR_NUMBER\"/" $MAIN_MANIFEST
+else
+  echo "$MAIN_MANIFEST does not exist."
+fi
+
+if [ -f "$DEBUG_MANIFEST" ]; then
+  echo "Updating $DEBUG_MANIFEST with PR number $PR_NUMBER"
+  sed -i "s/package=\"org.catrobat.paintroid\"/package=\"org.catrobat.paintroid.pr$PR_NUMBER\"/" $DEBUG_MANIFEST
+else
+  echo "$DEBUG_MANIFEST does not exist."
+fi
+
+if [ -f "$PROFILE_MANIFEST" ]; then
+  echo "Updating $PROFILE_MANIFEST with PR number $PR_NUMBER"
+  sed -i "s/package=\"org.catrobat.paintroid\"/package=\"org.catrobat.paintroid.pr$PR_NUMBER\"/" $PROFILE_MANIFEST
+else
+  echo "$PROFILE_MANIFEST does not exist."
+fi
 
 INFO_PLIST="ios/Runner/Info.plist"
-xmlstarlet ed -L -u "/plist/dict/key[text()='CFBundleName']/following-sibling::string[1]" -v "paintroid PR$PR_NUMBER" $INFO_PLIST
-xmlstarlet ed -L -u "/plist/dict/key[text()='CFBundleIdentifier']/following-sibling::string[1]" -v "org.catrobat.paintroidflutter.pr$PR_NUMBER" $INFO_PLIST
+if [ -f "$INFO_PLIST" ]; then
+  echo "Updating $INFO_PLIST with PR number $PR_NUMBER"
+  xmlstarlet ed -L -u "/plist/dict/key[text()='CFBundleName']/following-sibling::string[1]" -v "paintroid PR$PR_NUMBER" $INFO_PLIST
+  xmlstarlet ed -L -u "/plist/dict/key[text()='CFBundleDisplayName']/following-sibling::string[1]" -v "Pocket Paint PR$PR_NUMBER" $INFO_PLIST
+  if ! xmlstarlet sel -t -c "/plist/dict/key[text()='CFBundleDisplayName']" $INFO_PLIST | grep -q 'CFBundleDisplayName'; then
+    xmlstarlet ed -L -s "/plist/dict" -t elem -n "key" -v "CFBundleDisplayName" \
+      -s "/plist/dict/key[last()]" -t elem -n "string" -v "Pocket Paint PR$PR_NUMBER" $INFO_PLIST
+  fi
+  xmlstarlet ed -L -u "/plist/dict/key[text()='CFBundleIdentifier']/following-sibling::string[1]" -v "org.catrobat.paintroidflutter.pr$PR_NUMBER" $INFO_PLIST
+else
+  echo "$INFO_PLIST does not exist."
+fi


### PR DESCRIPTION
Ticket : Paintroid-721 
https://catrobat.atlassian.net/browse/PAINTROID-721

Description
Add the PR number to the app name, so we can see which version is installed instantly.
Also change the app identifier so that we are able to install multiple apps from different PRs at the same time.

## New Features and Enhancements
- New Features and Enhancements
## Refactorings and Bug Fixes
- Refactorings and Bug Fixes

## Checklist

#### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

