### PR TITLE
PAINRTOID-763: RedoStack not cleared for new project

### DIFF
--- a/lib/core/providers/state/canvas_state_provider.dart
+++ b/lib/core/providers/state/canvas_state_provider.dart
@@ -2,14 +2,12 @@ import 'dart:ui';
 
 import 'package:flutter/painting.dart';
 import 'package:flutter/widgets.dart' as widgets;
-
-import 'package:riverpod_annotation/riverpod_annotation.dart';
-
 import 'package:paintroid/core/commands/command_implementation/command.dart';
 import 'package:paintroid/core/commands/command_manager/command_manager_provider.dart';
 import 'package:paintroid/core/commands/graphic_factory/graphic_factory_provider.dart';
 import 'package:paintroid/core/providers/object/device_service.dart';
 import 'package:paintroid/core/providers/state/canvas_state_data.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'canvas_state_provider.g.dart';
 
@@ -64,6 +62,7 @@ class CanvasStateProvider extends _$CanvasStateProvider {
   }
 
   Future<void> resetCanvasWithNewCommands(Iterable<Command> commands) async {
+    state.commandManager.clearRedoStack();
     state.commandManager.clearUndoStack(newCommands: commands);
     if (commands.isEmpty) {
       state = state.copyWith(cachedImage: null);

--- a/lib/core/utils/widget_identifier.dart
+++ b/lib/core/utils/widget_identifier.dart
@@ -2,4 +2,5 @@ class WidgetIdentifier {
   static const canvasPainter = 'CanvasPainter';
   static const newImageActionButton = 'NewImageActionButton';
   static const circleShapeTypeChip = 'CircleShapeTypeChip';
+  static const backButton = 'BackButton';
 }

--- a/lib/core/utils/widget_identifier.dart
+++ b/lib/core/utils/widget_identifier.dart
@@ -3,4 +3,16 @@ class WidgetIdentifier {
   static const newImageActionButton = 'NewImageActionButton';
   static const circleShapeTypeChip = 'CircleShapeTypeChip';
   static const backButton = 'BackButton';
+
+  // GenericDialogAction
+  static const genericDialogActionDone = 'GenericDialogActionDone';
+  static const genericDialogActionDiscard = 'GenericDialogActionDiscard';
+  static const genericDialogActionSave = 'GenericDialogActionSave';
+  static const genericDialogActionPhotos = 'GenericDialogActionPhotos';
+  static const genericDialogActionFiles = 'GenericDialogActionFiles';
+  static const genericDialogActionCancel = 'GenericDialogActionCancel';
+  static const genericDialogActionDelete = 'GenericDialogActionDelete';
+  static const genericDialogActionOk = 'GenericDialogActionOk';
+  static const genericDialogActionRename = 'GenericDialogActionRename';
+  static const genericDialogActionYes = 'GenericDialogActionYes';
 }

--- a/lib/ui/pages/workspace_page/components/top_bar/top_app_bar.dart
+++ b/lib/ui/pages/workspace_page/components/top_bar/top_app_bar.dart
@@ -3,18 +3,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:paintroid/core/commands/command_manager/command_manager.dart';
 import 'package:paintroid/core/commands/command_manager/command_manager_provider.dart';
 import 'package:paintroid/core/enums/tool_types.dart';
-import 'package:paintroid/core/providers/object/io_handler.dart';
 import 'package:paintroid/core/providers/state/app_bar_provider.dart';
 import 'package:paintroid/core/providers/state/canvas_state_provider.dart';
 import 'package:paintroid/core/providers/state/paint_provider.dart';
 import 'package:paintroid/core/providers/state/toolbox_state_provider.dart';
-import 'package:paintroid/core/providers/state/workspace_state_notifier.dart';
 import 'package:paintroid/core/tools/line_tool/line_tool.dart';
 import 'package:paintroid/core/tools/tool.dart';
-import 'package:paintroid/core/utils/widget_identifier.dart';
 import 'package:paintroid/ui/pages/workspace_page/components/top_bar/overflow_menu.dart';
 import 'package:paintroid/ui/shared/action_button.dart';
-import 'package:paintroid/ui/shared/dialogs/discard_changes_dialog.dart';
 import 'package:paintroid/ui/utils/top_bar_action_data.dart';
 
 class TopAppBar extends ConsumerWidget implements PreferredSizeWidget {
@@ -24,31 +20,6 @@ class TopAppBar extends ConsumerWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);
-
-  Future<void Function()?> _onBack(BuildContext context, WidgetRef ref) async {
-    final isFullscreen = ref.watch(
-      workspaceStateProvider.select((state) => state.isFullscreen),
-    );
-    final ioHandler = ref.watch(IOHandler.provider);
-    final workspaceStateNotifier = ref.watch(workspaceStateProvider.notifier);
-
-    if (isFullscreen) {
-      workspaceStateNotifier.toggleFullscreen(false);
-      return null;
-    }
-    if (!workspaceStateNotifier.hasSavedLastWork) {
-      final shouldDiscard = await showDiscardChangesDialog(context);
-      if (shouldDiscard != null && !shouldDiscard && context.mounted) {
-        bool savedImage = await ioHandler.saveImage(context);
-        if (!savedImage) {
-          return null;
-        }
-      }
-    }
-    if (!context.mounted) return null;
-    Navigator.pop(context);
-    return null;
-  }
 
   void Function()? _onUndo(
     Tool currentTool,
@@ -129,13 +100,6 @@ class TopAppBar extends ConsumerWidget implements PreferredSizeWidget {
     ref.watch(appBarProvider);
 
     return AppBar(
-      leading: IconButton(
-        key: const ValueKey(WidgetIdentifier.backButton),
-        icon: const Icon(Icons.arrow_back),
-        onPressed: () async {
-          await _onBack(context, ref);
-        },
-      ),
       title: Text(title),
       centerTitle: false,
       actions: [

--- a/lib/ui/pages/workspace_page/components/top_bar/top_app_bar.dart
+++ b/lib/ui/pages/workspace_page/components/top_bar/top_app_bar.dart
@@ -3,14 +3,18 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:paintroid/core/commands/command_manager/command_manager.dart';
 import 'package:paintroid/core/commands/command_manager/command_manager_provider.dart';
 import 'package:paintroid/core/enums/tool_types.dart';
+import 'package:paintroid/core/providers/object/io_handler.dart';
 import 'package:paintroid/core/providers/state/app_bar_provider.dart';
 import 'package:paintroid/core/providers/state/canvas_state_provider.dart';
 import 'package:paintroid/core/providers/state/paint_provider.dart';
 import 'package:paintroid/core/providers/state/toolbox_state_provider.dart';
+import 'package:paintroid/core/providers/state/workspace_state_notifier.dart';
 import 'package:paintroid/core/tools/line_tool/line_tool.dart';
 import 'package:paintroid/core/tools/tool.dart';
+import 'package:paintroid/core/utils/widget_identifier.dart';
 import 'package:paintroid/ui/pages/workspace_page/components/top_bar/overflow_menu.dart';
 import 'package:paintroid/ui/shared/action_button.dart';
+import 'package:paintroid/ui/shared/dialogs/discard_changes_dialog.dart';
 import 'package:paintroid/ui/utils/top_bar_action_data.dart';
 
 class TopAppBar extends ConsumerWidget implements PreferredSizeWidget {
@@ -20,6 +24,31 @@ class TopAppBar extends ConsumerWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+
+  Future<void Function()?> _onBack(BuildContext context, WidgetRef ref) async {
+    final isFullscreen = ref.watch(
+      workspaceStateProvider.select((state) => state.isFullscreen),
+    );
+    final ioHandler = ref.watch(IOHandler.provider);
+    final workspaceStateNotifier = ref.watch(workspaceStateProvider.notifier);
+
+    if (isFullscreen) {
+      workspaceStateNotifier.toggleFullscreen(false);
+      return null;
+    }
+    if (!workspaceStateNotifier.hasSavedLastWork) {
+      final shouldDiscard = await showDiscardChangesDialog(context);
+      if (shouldDiscard != null && !shouldDiscard && context.mounted) {
+        bool savedImage = await ioHandler.saveImage(context);
+        if (!savedImage) {
+          return null;
+        }
+      }
+    }
+    if (!context.mounted) return null;
+    Navigator.pop(context);
+    return null;
+  }
 
   void Function()? _onUndo(
     Tool currentTool,
@@ -100,6 +129,13 @@ class TopAppBar extends ConsumerWidget implements PreferredSizeWidget {
     ref.watch(appBarProvider);
 
     return AppBar(
+      leading: IconButton(
+        key: const ValueKey(WidgetIdentifier.backButton),
+        icon: const Icon(Icons.arrow_back),
+        onPressed: () async {
+          await _onBack(context, ref);
+        },
+      ),
       title: Text(title),
       centerTitle: false,
       actions: [

--- a/lib/ui/pages/workspace_page/workspace_page.dart
+++ b/lib/ui/pages/workspace_page/workspace_page.dart
@@ -1,17 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:toast/toast.dart';
-
-import 'package:paintroid/core/providers/object/io_handler.dart';
 import 'package:paintroid/core/providers/state/workspace_state_notifier.dart';
 import 'package:paintroid/ui/pages/workspace_page/components/bottom_bar/bottom_nav_bar.dart';
 import 'package:paintroid/ui/pages/workspace_page/components/bottom_bar/tool_options/tool_options.dart';
 import 'package:paintroid/ui/pages/workspace_page/components/drawing_surface/drawing_canvas.dart';
 import 'package:paintroid/ui/pages/workspace_page/components/drawing_surface/exit_fullscreen_button.dart';
 import 'package:paintroid/ui/pages/workspace_page/components/top_bar/top_app_bar.dart';
-import 'package:paintroid/ui/shared/dialogs/discard_changes_dialog.dart';
+import 'package:toast/toast.dart';
 
 class WorkspacePage extends ConsumerStatefulWidget {
   const WorkspacePage({super.key});
@@ -39,30 +35,7 @@ class _WorkspaceScreenState extends ConsumerState<WorkspacePage> {
       workspaceStateProvider.select((state) => state.isFullscreen),
       (_, isFullscreen) => _toggleStatusBar(isFullscreen),
     );
-    final ioHandler = ref.watch(IOHandler.provider);
-    final workspaceStateNotifier = ref.watch(workspaceStateProvider.notifier);
     return PopScope(
-      canPop: false,
-      onPopInvoked: (didPop) async {
-        if (didPop) {
-          return;
-        }
-        if (isFullscreen) {
-          workspaceStateNotifier.toggleFullscreen(false);
-          return;
-        }
-        if (!workspaceStateNotifier.hasSavedLastWork) {
-          final shouldDiscard = await showDiscardChangesDialog(context);
-          if (shouldDiscard != null && !shouldDiscard && context.mounted) {
-            bool savedImage = await ioHandler.saveImage(context);
-            if (!savedImage) {
-              return;
-            }
-          }
-        }
-        if (!context.mounted) return;
-        Navigator.pop(context);
-      },
       child: Scaffold(
         appBar: isFullscreen ? null : const TopAppBar(title: 'Pocket Paint'),
         backgroundColor: Colors.grey.shade400,

--- a/lib/ui/pages/workspace_page/workspace_page.dart
+++ b/lib/ui/pages/workspace_page/workspace_page.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:paintroid/core/providers/object/io_handler.dart';
 import 'package:paintroid/core/providers/state/workspace_state_notifier.dart';
 import 'package:paintroid/ui/pages/workspace_page/components/bottom_bar/bottom_nav_bar.dart';
 import 'package:paintroid/ui/pages/workspace_page/components/bottom_bar/tool_options/tool_options.dart';
 import 'package:paintroid/ui/pages/workspace_page/components/drawing_surface/drawing_canvas.dart';
 import 'package:paintroid/ui/pages/workspace_page/components/drawing_surface/exit_fullscreen_button.dart';
 import 'package:paintroid/ui/pages/workspace_page/components/top_bar/top_app_bar.dart';
+import 'package:paintroid/ui/shared/dialogs/discard_changes_dialog.dart';
 import 'package:toast/toast.dart';
 
 class WorkspacePage extends ConsumerStatefulWidget {
@@ -35,7 +37,30 @@ class _WorkspaceScreenState extends ConsumerState<WorkspacePage> {
       workspaceStateProvider.select((state) => state.isFullscreen),
       (_, isFullscreen) => _toggleStatusBar(isFullscreen),
     );
+    final ioHandler = ref.watch(IOHandler.provider);
+    final workspaceStateNotifier = ref.watch(workspaceStateProvider.notifier);
     return PopScope(
+      canPop: false,
+      onPopInvoked: (didPop) async {
+        if (didPop) {
+          return;
+        }
+        if (isFullscreen) {
+          workspaceStateNotifier.toggleFullscreen(false);
+          return;
+        }
+        if (!workspaceStateNotifier.hasSavedLastWork) {
+          final shouldDiscard = await showDiscardChangesDialog(context);
+          if (shouldDiscard != null && !shouldDiscard && context.mounted) {
+            bool savedImage = await ioHandler.saveImage(context);
+            if (!savedImage) {
+              return;
+            }
+          }
+        }
+        if (!context.mounted) return;
+        Navigator.pop(context);
+      },
       child: Scaffold(
         appBar: isFullscreen ? null : const TopAppBar(title: 'Pocket Paint'),
         backgroundColor: Colors.grey.shade400,

--- a/lib/ui/shared/dialogs/about_dialog.dart
+++ b/lib/ui/shared/dialogs/about_dialog.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-
 import 'package:paintroid/core/utils/open_url.dart';
+import 'package:paintroid/core/utils/widget_identifier.dart';
 import 'package:paintroid/ui/shared/dialogs/generic_dialog.dart';
 import 'package:paintroid/ui/shared/images/pocketpaint_logo_small.dart';
 import 'package:paintroid/ui/theme/theme.dart';
@@ -54,7 +53,10 @@ class _MyAboutDialogState extends ConsumerState<MyAboutDialog> {
       title: 'About',
       actions: [
         GenericDialogAction(
-            title: 'DONE', onPressed: () => Navigator.of(context).pop(true)),
+          title: 'DONE',
+          onPressed: () => Navigator.of(context).pop(true),
+          key: const ValueKey(WidgetIdentifier.genericDialogActionDone),
+        ),
       ],
       content: Column(
         mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/ui/shared/dialogs/about_dialog.dart
+++ b/lib/ui/shared/dialogs/about_dialog.dart
@@ -55,7 +55,7 @@ class _MyAboutDialogState extends ConsumerState<MyAboutDialog> {
         GenericDialogAction(
           title: 'DONE',
           onPressed: () => Navigator.of(context).pop(true),
-          key: const ValueKey(WidgetIdentifier.genericDialogActionDone),
+          identifier: WidgetIdentifier.genericDialogActionDone,
         ),
       ],
       content: Column(

--- a/lib/ui/shared/dialogs/delete_project_dialog.dart
+++ b/lib/ui/shared/dialogs/delete_project_dialog.dart
@@ -12,16 +12,12 @@ Future<bool?> showDeleteDialog(BuildContext context, String name) =>
                   GenericDialogAction(
                     title: 'Cancel',
                     onPressed: () => Navigator.of(context).pop(false),
-                    key: const ValueKey(
-                      WidgetIdentifier.genericDialogActionCancel,
-                    ),
+                    identifier: WidgetIdentifier.genericDialogActionCancel,
                   ),
                   GenericDialogAction(
                     title: 'Delete',
                     onPressed: () => Navigator.of(context).pop(true),
-                    key: const ValueKey(
-                      WidgetIdentifier.genericDialogActionDelete,
-                    ),
+                    identifier: WidgetIdentifier.genericDialogActionDelete,
                   ),
                 ]),
         barrierDismissible: true,

--- a/lib/ui/shared/dialogs/delete_project_dialog.dart
+++ b/lib/ui/shared/dialogs/delete_project_dialog.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-
+import 'package:paintroid/core/utils/widget_identifier.dart';
 import 'package:paintroid/ui/shared/dialogs/generic_dialog.dart';
 
 Future<bool?> showDeleteDialog(BuildContext context, String name) =>
@@ -10,11 +10,19 @@ Future<bool?> showDeleteDialog(BuildContext context, String name) =>
                 text: 'Do you really want to delete your project?',
                 actions: [
                   GenericDialogAction(
-                      title: 'Cancel',
-                      onPressed: () => Navigator.of(context).pop(false)),
+                    title: 'Cancel',
+                    onPressed: () => Navigator.of(context).pop(false),
+                    key: const ValueKey(
+                      WidgetIdentifier.genericDialogActionCancel,
+                    ),
+                  ),
                   GenericDialogAction(
-                      title: 'Delete',
-                      onPressed: () => Navigator.of(context).pop(true)),
+                    title: 'Delete',
+                    onPressed: () => Navigator.of(context).pop(true),
+                    key: const ValueKey(
+                      WidgetIdentifier.genericDialogActionDelete,
+                    ),
+                  ),
                 ]),
         barrierDismissible: true,
         barrierLabel: 'Show delete project dialog box');

--- a/lib/ui/shared/dialogs/discard_changes_dialog.dart
+++ b/lib/ui/shared/dialogs/discard_changes_dialog.dart
@@ -13,16 +13,12 @@ Future<bool?> showDiscardChangesDialog(BuildContext context) =>
                   GenericDialogAction(
                     title: 'Discard',
                     onPressed: () => Navigator.of(context).pop(true),
-                    key: const ValueKey(
-                      WidgetIdentifier.genericDialogActionDiscard,
-                    ),
+                    identifier: WidgetIdentifier.genericDialogActionDiscard,
                   ),
                   GenericDialogAction(
                     title: 'Save',
                     onPressed: () => Navigator.of(context).pop(false),
-                    key: const ValueKey(
-                      WidgetIdentifier.genericDialogActionSave,
-                    ),
+                    identifier: WidgetIdentifier.genericDialogActionSave,
                   ),
                 ]),
         barrierDismissible: true,

--- a/lib/ui/shared/dialogs/discard_changes_dialog.dart
+++ b/lib/ui/shared/dialogs/discard_changes_dialog.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-
+import 'package:paintroid/core/utils/widget_identifier.dart';
 import 'package:paintroid/ui/shared/dialogs/generic_dialog.dart';
 
 Future<bool?> showDiscardChangesDialog(BuildContext context) =>
@@ -11,11 +11,19 @@ Future<bool?> showDiscardChangesDialog(BuildContext context) =>
                     'You have not saved your last changes. They will be lost!',
                 actions: [
                   GenericDialogAction(
-                      title: 'Discard',
-                      onPressed: () => Navigator.of(context).pop(true)),
+                    title: 'Discard',
+                    onPressed: () => Navigator.of(context).pop(true),
+                    key: const ValueKey(
+                      WidgetIdentifier.genericDialogActionDiscard,
+                    ),
+                  ),
                   GenericDialogAction(
-                      title: 'Save',
-                      onPressed: () => Navigator.of(context).pop(false)),
+                    title: 'Save',
+                    onPressed: () => Navigator.of(context).pop(false),
+                    key: const ValueKey(
+                      WidgetIdentifier.genericDialogActionSave,
+                    ),
+                  ),
                 ]),
         barrierDismissible: true,
         barrierLabel: 'Dismiss discard changes dialog box');

--- a/lib/ui/shared/dialogs/generic_dialog.dart
+++ b/lib/ui/shared/dialogs/generic_dialog.dart
@@ -4,12 +4,18 @@ import 'package:paintroid/ui/theme/theme.dart';
 class GenericDialogActionButton extends StatelessWidget {
   final String text;
   final Function? onPressed;
+  final String identifier;
 
-  const GenericDialogActionButton(
-      {super.key, required this.text, this.onPressed});
+  const GenericDialogActionButton({
+    super.key,
+    required this.text,
+    this.onPressed,
+    required this.identifier,
+  });
 
   @override
   Widget build(BuildContext context) => TextButton(
+        key: ValueKey(identifier),
         style: ButtonStyle(
           foregroundColor: WidgetStateProperty.all(
             PaintroidTheme.of(context).primaryColor,
@@ -25,12 +31,12 @@ class GenericDialogActionButton extends StatelessWidget {
 class GenericDialogAction {
   final Function? onPressed;
   final String title;
-  final ValueKey key;
+  final String identifier;
 
   const GenericDialogAction({
     this.onPressed,
     required this.title,
-    required this.key,
+    required this.identifier,
   });
 }
 
@@ -40,12 +46,13 @@ class GenericDialog extends StatelessWidget {
   final Widget? content;
   final List<GenericDialogAction> actions;
 
-  const GenericDialog(
-      {super.key,
-      required this.title,
-      this.text,
-      this.content,
-      required this.actions});
+  const GenericDialog({
+    super.key,
+    required this.title,
+    this.text,
+    this.content,
+    required this.actions,
+  });
 
   Widget? getContent(BuildContext context) {
     if (content != null) {
@@ -75,6 +82,7 @@ class GenericDialog extends StatelessWidget {
             .map((action) => GenericDialogActionButton(
                   text: action.title,
                   onPressed: action.onPressed,
+                  identifier: action.identifier,
                 ))
             .toList(),
         content: getContent(context),

--- a/lib/ui/shared/dialogs/generic_dialog.dart
+++ b/lib/ui/shared/dialogs/generic_dialog.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-
 import 'package:paintroid/ui/theme/theme.dart';
 
 class GenericDialogActionButton extends StatelessWidget {
@@ -26,8 +25,13 @@ class GenericDialogActionButton extends StatelessWidget {
 class GenericDialogAction {
   final Function? onPressed;
   final String title;
+  final ValueKey key;
 
-  const GenericDialogAction({Key? key, this.onPressed, required this.title});
+  const GenericDialogAction({
+    this.onPressed,
+    required this.title,
+    required this.key,
+  });
 }
 
 class GenericDialog extends StatelessWidget {

--- a/lib/ui/shared/dialogs/load_image_dialog.dart
+++ b/lib/ui/shared/dialogs/load_image_dialog.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-
 import 'package:paintroid/core/enums/image_location.dart';
+import 'package:paintroid/core/utils/widget_identifier.dart';
 import 'package:paintroid/ui/shared/dialogs/generic_dialog.dart';
 
 Future<ImageLocation?> showLoadImageDialog(BuildContext context) =>
@@ -11,13 +11,21 @@ Future<ImageLocation?> showLoadImageDialog(BuildContext context) =>
               text: 'Where do you want to load the image from?',
               actions: [
                 GenericDialogAction(
-                    title: 'Photos',
-                    onPressed: () =>
-                        Navigator.of(context).pop(ImageLocation.photos)),
+                  title: 'Photos',
+                  onPressed: () =>
+                      Navigator.of(context).pop(ImageLocation.photos),
+                  key: const ValueKey(
+                    WidgetIdentifier.genericDialogActionPhotos,
+                  ),
+                ),
                 GenericDialogAction(
-                    title: 'Files',
-                    onPressed: () =>
-                        Navigator.of(context).pop(ImageLocation.files))
+                  title: 'Files',
+                  onPressed: () =>
+                      Navigator.of(context).pop(ImageLocation.files),
+                  key: const ValueKey(
+                    WidgetIdentifier.genericDialogActionFiles,
+                  ),
+                ),
               ],
             ),
         barrierDismissible: true,

--- a/lib/ui/shared/dialogs/load_image_dialog.dart
+++ b/lib/ui/shared/dialogs/load_image_dialog.dart
@@ -14,17 +14,13 @@ Future<ImageLocation?> showLoadImageDialog(BuildContext context) =>
                   title: 'Photos',
                   onPressed: () =>
                       Navigator.of(context).pop(ImageLocation.photos),
-                  key: const ValueKey(
-                    WidgetIdentifier.genericDialogActionPhotos,
-                  ),
+                  identifier: WidgetIdentifier.genericDialogActionPhotos,
                 ),
                 GenericDialogAction(
                   title: 'Files',
                   onPressed: () =>
                       Navigator.of(context).pop(ImageLocation.files),
-                  key: const ValueKey(
-                    WidgetIdentifier.genericDialogActionFiles,
-                  ),
+                  identifier: WidgetIdentifier.genericDialogActionFiles,
                 ),
               ],
             ),

--- a/lib/ui/shared/dialogs/overwrite_dialog.dart
+++ b/lib/ui/shared/dialogs/overwrite_dialog.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-
+import 'package:paintroid/core/utils/widget_identifier.dart';
 import 'package:paintroid/ui/shared/dialogs/generic_dialog.dart';
 
 Future<bool?> showOverwriteDialog(BuildContext context) =>
@@ -13,10 +13,12 @@ Future<bool?> showOverwriteDialog(BuildContext context) =>
           GenericDialogAction(
             title: 'Cancel',
             onPressed: () => Navigator.of(context).pop(true),
+            key: const ValueKey(WidgetIdentifier.genericDialogActionCancel),
           ),
           GenericDialogAction(
             title: 'Yes',
             onPressed: () => Navigator.of(context).pop(false),
+            key: const ValueKey(WidgetIdentifier.genericDialogActionYes),
           ),
         ],
       ),

--- a/lib/ui/shared/dialogs/overwrite_dialog.dart
+++ b/lib/ui/shared/dialogs/overwrite_dialog.dart
@@ -13,12 +13,12 @@ Future<bool?> showOverwriteDialog(BuildContext context) =>
           GenericDialogAction(
             title: 'Cancel',
             onPressed: () => Navigator.of(context).pop(true),
-            key: const ValueKey(WidgetIdentifier.genericDialogActionCancel),
+            identifier: WidgetIdentifier.genericDialogActionCancel,
           ),
           GenericDialogAction(
             title: 'Yes',
             onPressed: () => Navigator.of(context).pop(false),
-            key: const ValueKey(WidgetIdentifier.genericDialogActionYes),
+            identifier: WidgetIdentifier.genericDialogActionYes,
           ),
         ],
       ),

--- a/lib/ui/shared/dialogs/project_details_dialog.dart
+++ b/lib/ui/shared/dialogs/project_details_dialog.dart
@@ -45,7 +45,7 @@ class _ProjectDetailsDialogState extends ConsumerState<ProjectDetailsDialog> {
         GenericDialogAction(
           title: 'OK',
           onPressed: () => Navigator.of(context).pop(false),
-          key: const ValueKey(WidgetIdentifier.genericDialogActionOk),
+          identifier: WidgetIdentifier.genericDialogActionOk,
         ),
       ],
       content: FutureBuilder(

--- a/lib/ui/shared/dialogs/project_details_dialog.dart
+++ b/lib/ui/shared/dialogs/project_details_dialog.dart
@@ -1,13 +1,12 @@
-import 'package:flutter/material.dart';
-
 import 'package:filesize/filesize.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:oxidized/oxidized.dart';
-
 import 'package:paintroid/core/models/database/project.dart';
 import 'package:paintroid/core/providers/object/file_service.dart';
 import 'package:paintroid/core/providers/object/image_service.dart';
+import 'package:paintroid/core/utils/widget_identifier.dart';
 import 'package:paintroid/ui/shared/dialogs/generic_dialog.dart';
 import 'package:paintroid/ui/theme/theme.dart';
 import 'package:paintroid/ui/utils/toast_utils.dart';
@@ -44,7 +43,10 @@ class _ProjectDetailsDialogState extends ConsumerState<ProjectDetailsDialog> {
       title: widget.project.name,
       actions: [
         GenericDialogAction(
-            title: 'OK', onPressed: () => Navigator.of(context).pop(false))
+          title: 'OK',
+          onPressed: () => Navigator.of(context).pop(false),
+          key: const ValueKey(WidgetIdentifier.genericDialogActionOk),
+        ),
       ],
       content: FutureBuilder(
         future: _getImageDimensions(widget.project.imagePreviewPath),

--- a/lib/ui/shared/dialogs/rename_project_dialog.dart
+++ b/lib/ui/shared/dialogs/rename_project_dialog.dart
@@ -18,7 +18,7 @@ Future<String?> showRenameDialog(BuildContext context, String name) async {
           GenericDialogAction(
               title: 'CANCEL',
               onPressed: () => Navigator.of(context).pop(),
-              key: const ValueKey(WidgetIdentifier.genericDialogActionCancel)),
+              identifier: WidgetIdentifier.genericDialogActionCancel),
           GenericDialogAction(
             title: 'RENAME',
             onPressed: () {
@@ -28,7 +28,7 @@ Future<String?> showRenameDialog(BuildContext context, String name) async {
               }
               Navigator.of(context).pop(textFieldController.text);
             },
-            key: const ValueKey(WidgetIdentifier.genericDialogActionRename),
+            identifier: WidgetIdentifier.genericDialogActionRename,
           ),
         ],
         content: Form(

--- a/lib/ui/shared/dialogs/rename_project_dialog.dart
+++ b/lib/ui/shared/dialogs/rename_project_dialog.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-
+import 'package:paintroid/core/utils/widget_identifier.dart';
 import 'package:paintroid/ui/shared/dialogs/generic_dialog.dart';
 import 'package:paintroid/ui/shared/text_input_field.dart';
 
@@ -16,9 +16,9 @@ Future<String?> showRenameDialog(BuildContext context, String name) async {
         title: 'Rename $name',
         actions: [
           GenericDialogAction(
-            title: 'CANCEL',
-            onPressed: () => Navigator.of(context).pop(),
-          ),
+              title: 'CANCEL',
+              onPressed: () => Navigator.of(context).pop(),
+              key: const ValueKey(WidgetIdentifier.genericDialogActionCancel)),
           GenericDialogAction(
             title: 'RENAME',
             onPressed: () {
@@ -28,6 +28,7 @@ Future<String?> showRenameDialog(BuildContext context, String name) async {
               }
               Navigator.of(context).pop(textFieldController.text);
             },
+            key: const ValueKey(WidgetIdentifier.genericDialogActionRename),
           ),
         ],
         content: Form(

--- a/test/integration/app_workflow_test.dart
+++ b/test/integration/app_workflow_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:paintroid/app.dart';
+import 'package:paintroid/core/tools/tool_data.dart';
+
+import '../utils/test_utils.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const String testIDStr = String.fromEnvironment('id', defaultValue: '-1');
+  final testID = int.tryParse(testIDStr) ?? testIDStr;
+
+  late Widget sut;
+
+  setUp(() async {
+    sut = ProviderScope(
+      child: App(
+        showOnboardingPage: false,
+      ),
+    );
+  });
+
+  if (testID == -1 || testID == 0) {
+    testWidgets('[GENERAL]: undo stack is empty for new image',
+        (WidgetTester tester) async {
+      UIInteraction.initialize(tester);
+      await tester.pumpWidget(sut);
+      await UIInteraction.createNewImage();
+
+      var undoStackLength = UIInteraction.getUndoStackLength();
+      expect(undoStackLength, 0);
+
+      await UIInteraction.selectTool(ToolData.BRUSH.name);
+      await UIInteraction.tapAt(CanvasPosition.center);
+
+      undoStackLength = UIInteraction.getUndoStackLength();
+      expect(undoStackLength, 1);
+
+      await UIInteraction.clickBackButton();
+      await UIInteraction.clickDiscard();
+      await UIInteraction.createNewImage();
+
+      undoStackLength = UIInteraction.getUndoStackLength();
+      expect(undoStackLength, 0);
+    });
+  }
+
+  if (testID == -1 || testID == 1) {
+    testWidgets('[GENERAL]: redo stack is empty for new image with empty image',
+        (WidgetTester tester) async {
+      UIInteraction.initialize(tester);
+      await tester.pumpWidget(sut);
+      await UIInteraction.createNewImage();
+
+      var redoStackLength = UIInteraction.getRedoStackLength();
+      expect(redoStackLength, 0);
+
+      await UIInteraction.selectTool(ToolData.BRUSH.name);
+      await UIInteraction.tapAt(CanvasPosition.center);
+
+      redoStackLength = UIInteraction.getRedoStackLength();
+      expect(redoStackLength, 0);
+
+      await UIInteraction.clickUndo();
+
+      redoStackLength = UIInteraction.getRedoStackLength();
+      expect(redoStackLength, 1);
+
+      await UIInteraction.clickBackButton();
+      await UIInteraction.createNewImage();
+
+      redoStackLength = UIInteraction.getRedoStackLength();
+      expect(redoStackLength, 0);
+    });
+  }
+
+  if (testID == -1 || testID == 2) {
+    testWidgets(
+        '[GENERAL]: redo stack is empty for new image with non empty image',
+        (WidgetTester tester) async {
+      UIInteraction.initialize(tester);
+      await tester.pumpWidget(sut);
+      await UIInteraction.createNewImage();
+
+      var redoStackLength = UIInteraction.getRedoStackLength();
+      expect(redoStackLength, 0);
+      var undoStackLength = UIInteraction.getUndoStackLength();
+      expect(undoStackLength, 0);
+
+      await UIInteraction.selectTool(ToolData.BRUSH.name);
+      await UIInteraction.tapAt(CanvasPosition.centerLeft);
+      await UIInteraction.tapAt(CanvasPosition.centerRight);
+
+      undoStackLength = UIInteraction.getUndoStackLength();
+      expect(undoStackLength, 2);
+      redoStackLength = UIInteraction.getRedoStackLength();
+      expect(redoStackLength, 0);
+
+      await UIInteraction.clickUndo();
+
+      undoStackLength = UIInteraction.getUndoStackLength();
+      expect(undoStackLength, 1);
+      redoStackLength = UIInteraction.getRedoStackLength();
+      expect(redoStackLength, 1);
+
+      await UIInteraction.clickBackButton();
+      await UIInteraction.clickDiscard();
+      await UIInteraction.createNewImage();
+
+      undoStackLength = UIInteraction.getUndoStackLength();
+      expect(undoStackLength, 0);
+      redoStackLength = UIInteraction.getRedoStackLength();
+      expect(redoStackLength, 0);
+    });
+  }
+}

--- a/test/utils/ui_interaction.dart
+++ b/test/utils/ui_interaction.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image/image.dart' as img;
 import 'package:paintroid/app.dart';
+import 'package:paintroid/core/commands/command_manager/command_manager_provider.dart';
 import 'package:paintroid/core/commands/graphic_factory/graphic_factory.dart';
 import 'package:paintroid/core/providers/object/tools/shapes_tool_provider.dart';
 import 'package:paintroid/core/providers/state/canvas_state_provider.dart';
@@ -219,5 +220,19 @@ class UIInteraction {
   static void expectVertexStackLength(int length) {
     final tool = getCurrentTool();
     expect((tool as LineTool).vertexStack.length, length);
+  }
+
+  static int getUndoStackLength() {
+    final container =
+        ProviderScope.containerOf(tester.element(find.byType(App)));
+    final commandManager = container.read(commandManagerProvider);
+    return commandManager.undoStack.length;
+  }
+
+  static int getRedoStackLength() {
+    final container =
+        ProviderScope.containerOf(tester.element(find.byType(App)));
+    final commandManager = container.read(commandManagerProvider);
+    return commandManager.redoStack.length;
   }
 }

--- a/test/utils/ui_interaction.dart
+++ b/test/utils/ui_interaction.dart
@@ -155,6 +155,12 @@ class UIInteraction {
     container.read(paintProvider.notifier).updateColor(color);
   }
 
+  static Future<void> clickBackButton() async {
+    expect(WidgetFinder.backButton, findsOneWidget);
+    await tester.tap(WidgetFinder.backButton);
+    await tester.pumpAndSettle();
+  }
+
   static Future<void> clickCheckmark() async {
     expect(WidgetFinder.checkMark, findsOneWidget);
     await tester.tap(WidgetFinder.checkMark);

--- a/test/utils/ui_interaction.dart
+++ b/test/utils/ui_interaction.dart
@@ -156,8 +156,13 @@ class UIInteraction {
   }
 
   static Future<void> clickBackButton() async {
-    expect(WidgetFinder.backButton, findsOneWidget);
-    await tester.tap(WidgetFinder.backButton);
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+  }
+
+  static Future<void> clickDiscard() async {
+    expect(WidgetFinder.genericDialogActionDiscard, findsOneWidget);
+    await tester.tap(WidgetFinder.genericDialogActionDiscard);
     await tester.pumpAndSettle();
   }
 

--- a/test/utils/widget_finder.dart
+++ b/test/utils/widget_finder.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/cupertino.dart';
-
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:paintroid/core/utils/widget_identifier.dart';
 import 'package:paintroid/ui/pages/workspace_page/components/bottom_bar/bottom_nav_bar_items.dart';
 import 'package:paintroid/ui/utils/top_bar_action_data.dart';
@@ -21,7 +19,8 @@ class WidgetFinder {
       find.byKey(ValueKey(TopBarActionData.UNDO.name));
   static final Finder redoButton =
       find.byKey(ValueKey(TopBarActionData.REDO.name));
-
   static final Finder circleShapeTypeChip =
       find.byKey(const ValueKey(WidgetIdentifier.circleShapeTypeChip));
+  static final Finder backButton =
+      find.byKey(const ValueKey(WidgetIdentifier.backButton));
 }

--- a/test/utils/widget_finder.dart
+++ b/test/utils/widget_finder.dart
@@ -23,4 +23,25 @@ class WidgetFinder {
       find.byKey(const ValueKey(WidgetIdentifier.circleShapeTypeChip));
   static final Finder backButton =
       find.byKey(const ValueKey(WidgetIdentifier.backButton));
+
+  static final Finder genericDialogActionDone =
+      find.byKey(const ValueKey(WidgetIdentifier.genericDialogActionDone));
+  static final Finder genericDialogActionDiscard =
+      find.byKey(const ValueKey(WidgetIdentifier.genericDialogActionDiscard));
+  static final Finder genericDialogActionSave =
+      find.byKey(const ValueKey(WidgetIdentifier.genericDialogActionSave));
+  static final Finder genericDialogActionPhotos =
+      find.byKey(const ValueKey(WidgetIdentifier.genericDialogActionPhotos));
+  static final Finder genericDialogActionFiles =
+      find.byKey(const ValueKey(WidgetIdentifier.genericDialogActionFiles));
+  static final Finder genericDialogActionCancel =
+      find.byKey(const ValueKey(WidgetIdentifier.genericDialogActionCancel));
+  static final Finder genericDialogActionDelete =
+      find.byKey(const ValueKey(WidgetIdentifier.genericDialogActionDelete));
+  static final Finder genericDialogActionOk =
+      find.byKey(const ValueKey(WidgetIdentifier.genericDialogActionOk));
+  static final Finder genericDialogActionRename =
+      find.byKey(const ValueKey(WidgetIdentifier.genericDialogActionRename));
+  static final Finder genericDialogActionYes =
+      find.byKey(const ValueKey(WidgetIdentifier.genericDialogActionYes));
 }


### PR DESCRIPTION
[PAINTROID-763](https://catrobat.atlassian.net/browse/PAINTROID-763)

## New Features and Enhancements
- extended test framework with click Back and Discard (GenericActionButton) buttons
- Added identifier to all GenericActionButtons in order to make them identifiable by ValueKey for testing
- wrote tests for all cases
   - non-empty undoStack / empty redoStack
   - empty undoStack / non-empty redoStack
   - non-empty undoStack / non-empty redoStack
## Refactorings and Bug Fixes
- fixed

## Checklist

#### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Add the link to the ticket in Jira in the description of the PR
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines (Wiki)
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Add new information to the [Wiki](https://github.com/Catrobat/Paintroid-Flutter/wiki)



[PAINTROID-763]: https://catrobat.atlassian.net/browse/PAINTROID-763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ