### PR TITLE
PAINTROID-748: Write Integration tests for BrushTool

### DIFF
--- a/test/integration/brush_tool_test.dart
+++ b/test/integration/brush_tool_test.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:paintroid/app.dart';
+import 'package:paintroid/core/tools/tool_data.dart';
+
+import '../utils/canvas_positions.dart';
+import '../utils/ui_interaction.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const String testIDStr = String.fromEnvironment('id', defaultValue: '-1');
+  final testID = int.tryParse(testIDStr) ?? testIDStr;
+
+  late Widget sut;
+
+  setUp(() async {
+    sut = ProviderScope(
+      child: App(
+        showOnboardingPage: false,
+      ),
+    );
+  });
+
+  if (testID == -1 || testID == 0) {
+    testWidgets('[BRUSH_TOOL]: drawing a point', (WidgetTester tester) async {
+      UIInteraction.initialize(tester);
+      await tester.pumpWidget(sut);
+      await UIInteraction.createNewImage();
+      UIInteraction.setColor(Colors.black);
+      await UIInteraction.selectTool(ToolData.BRUSH.name);
+
+      var color = await UIInteraction.getPixelColor(
+        CanvasPosition.centerX,
+        CanvasPosition.centerY,
+      );
+      expect(color, Colors.transparent);
+
+      await UIInteraction.tapAt(CanvasPosition.center);
+
+      color = await UIInteraction.getPixelColor(
+        CanvasPosition.centerX,
+        CanvasPosition.centerY,
+      );
+      expect(color, Colors.black);
+    });
+  }
+
+  if (testID == -1 || testID == 1) {
+    testWidgets('[BRUSH_TOOL]: drawing a line with drag',
+        (WidgetTester tester) async {
+      UIInteraction.initialize(tester);
+      await tester.pumpWidget(sut);
+      await UIInteraction.createNewImage();
+      UIInteraction.setColor(Colors.black);
+      await UIInteraction.selectTool(ToolData.BRUSH.name);
+
+      await UIInteraction.dragFromTo(
+        CanvasPosition.topLeft,
+        CanvasPosition.bottomRight,
+      );
+
+      var color = await UIInteraction.getPixelColor(
+        CanvasPosition.centerX,
+        CanvasPosition.centerY,
+      );
+      expect(color, Colors.black);
+    });
+  }
+
+  if (testID == -1 || testID == 2) {
+    testWidgets('[BRUSH_TOOL]: undo and redo drawing',
+        (WidgetTester tester) async {
+      UIInteraction.initialize(tester);
+      await tester.pumpWidget(sut);
+      await UIInteraction.createNewImage();
+      UIInteraction.setColor(Colors.black);
+      await UIInteraction.selectTool(ToolData.BRUSH.name);
+
+      await UIInteraction.tapAt(CanvasPosition.center);
+
+      var color = await UIInteraction.getPixelColor(
+        CanvasPosition.centerX,
+        CanvasPosition.centerY,
+      );
+      expect(color, Colors.black);
+
+      await UIInteraction.clickUndo();
+
+      color = await UIInteraction.getPixelColor(
+        CanvasPosition.centerX,
+        CanvasPosition.centerY,
+      );
+      expect(color, Colors.transparent);
+
+      await UIInteraction.clickRedo();
+
+      color = await UIInteraction.getPixelColor(
+        CanvasPosition.centerX,
+        CanvasPosition.centerY,
+      );
+      expect(color, Colors.black);
+    });
+  }
+
+  if (testID == -1 || testID == 3) {
+    testWidgets('[BRUSH_TOOL]: drawing multiple points',
+        (WidgetTester tester) async {
+      UIInteraction.initialize(tester);
+      await tester.pumpWidget(sut);
+      await UIInteraction.createNewImage();
+      UIInteraction.setColor(Colors.black);
+      await UIInteraction.selectTool(ToolData.BRUSH.name);
+
+      await UIInteraction.tapAt(CanvasPosition.topLeft);
+      await UIInteraction.tapAt(CanvasPosition.topRight);
+      await UIInteraction.tapAt(CanvasPosition.bottomLeft);
+      await UIInteraction.tapAt(CanvasPosition.bottomRight);
+
+      var color = await UIInteraction.getPixelColor(
+        CanvasPosition.left,
+        CanvasPosition.top,
+      );
+      expect(color, Colors.black);
+
+      color = await UIInteraction.getPixelColor(
+        CanvasPosition.right,
+        CanvasPosition.top,
+      );
+      expect(color, Colors.black);
+
+      color = await UIInteraction.getPixelColor(
+        CanvasPosition.left,
+        CanvasPosition.bottom,
+      );
+      expect(color, Colors.black);
+
+      color = await UIInteraction.getPixelColor(
+        CanvasPosition.right,
+        CanvasPosition.bottom,
+      );
+      expect(color, Colors.black);
+    });
+  }
+
+  if (testID == -1 || testID == 4) {
+    testWidgets('[BRUSH_TOOL]: drawing a line over another line',
+        (WidgetTester tester) async {
+      UIInteraction.initialize(tester);
+      await tester.pumpWidget(sut);
+      await UIInteraction.createNewImage();
+      UIInteraction.setColor(Colors.black);
+      await UIInteraction.selectTool(ToolData.BRUSH.name);
+
+      await UIInteraction.dragFromTo(
+        CanvasPosition.topLeft,
+        CanvasPosition.bottomRight,
+      );
+
+      var color = await UIInteraction.getPixelColor(
+        CanvasPosition.centerX,
+        CanvasPosition.centerY,
+      );
+      expect(color, Colors.black);
+
+      UIInteraction.setColor(Colors.red);
+
+      await UIInteraction.dragFromTo(
+        CanvasPosition.topRight,
+        CanvasPosition.bottomLeft,
+      );
+
+      color = await UIInteraction.getPixelColor(
+        CanvasPosition.centerX,
+        CanvasPosition.centerY,
+      );
+      expect(color.value, Colors.red.value);
+    });
+  }
+}


### PR DESCRIPTION
[PAINTROID-748](https://catrobat.atlassian.net/browse/PAINTROID-748)

## New Features and Enhancements
- added tests for brush-tool
  - draw one point
  - draw multiple points
  - undo / redo
  - draw over another path
 
## Checklist

#### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Add the link to the ticket in Jira in the description of the PR
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines (Wiki)
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Add new information to the [Wiki](https://github.com/Catrobat/Paintroid-Flutter/wiki)



[PAINTROID-751]: https://catrobat.atlassian.net/browse/PAINTROID-751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PAINTROID-748]: https://catrobat.atlassian.net/browse/PAINTROID-748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ