### PR TITLE
Fix project description visibility in light mode

### DIFF
--- a/lib/ui/pages/landing_page/components/project_list_tile.dart
+++ b/lib/ui/pages/landing_page/components/project_list_tile.dart
@@ -37,11 +37,11 @@ class ProjectListTile extends StatelessWidget {
         dense: false,
         title: Text(
           project.name,
-          style: const TextStyle(color: Color(0xFFFFFFFF)),
+          style: TextStyle(color: PaintroidTheme.of(context).titleStyle.decorationColor),
         ),
         subtitle: Text(
           'last modified: ${dateFormat.format(project.lastModified)}',
-          style: const TextStyle(color: Color(0xFFFFFFFF)),
+          style: TextStyle(color: PaintroidTheme.of(context).titleStyle.decorationColor),
         ),
         trailing: ProjectOverflowMenu(
           key: Key('ProjectOverflowMenu Key$index'),


### PR DESCRIPTION
> **Note:** I did not include the name of the Jira ticket in the PR’s title or add a link to the Jira ticket in the PR description because this is a new issue that is not on Jira.


*The project description is not clearly visible in light mode but is clearly visible in dark mode.*

## New Features and Enhancements
- Updated the color of the project description for better visibility in light mode.


## Refactorings and Bug Fixes

### Before
https://github.com/user-attachments/assets/2bade746-2831-4187-9df9-624a59f6409d


### After
https://github.com/user-attachments/assets/36fdbd60-565a-4c43-9ad0-a22705f225f5


## Checklist

#### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Add the link to the ticket in Jira in the description of the PR
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines (Wiki)
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Add new information to the [Wiki](https://github.com/Catrobat/Paintroid-Flutter/wiki)

