### PR TITLE
Fixing navigation bar color match the background color

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -8,6 +8,7 @@ import 'package:paintroid/ui/pages/onboarding_page/onboarding_page.dart';
 import 'package:paintroid/ui/pages/workspace_page/workspace_page.dart';
 import 'package:paintroid/ui/shared/loading_overlay.dart';
 import 'package:paintroid/ui/theme/theme.dart';
+import 'package:flutter/services.dart';
 
 class App extends StatelessWidget {
   final bool showOnboardingPage;
@@ -57,6 +58,14 @@ class App extends StatelessWidget {
         },
         home: Consumer(
           builder: (BuildContext context, WidgetRef ref, Widget? child) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              final navBarColor = PaintroidTheme.of(context).primaryColor;
+              SystemChrome.setSystemUIOverlayStyle(
+                SystemUiOverlayStyle(
+                  systemNavigationBarColor: navBarColor,
+                ),
+              );
+            });
             return LoadingOverlay(
               isLoading: ref.watch(
                 workspaceStateProvider.select(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-
+import 'package:flutter/services.dart';
 import 'package:paintroid/app.dart';
 
 void main() async {
@@ -27,6 +27,6 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final prefs = await SharedPreferences.getInstance();
   final showOnboarding = prefs.getBool('showOnboarding') ?? true;
-
+  SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
   runApp(ProviderScope(child: App(showOnboardingPage: showOnboarding)));
 }


### PR DESCRIPTION
This PR addresses  [PAINTROID-727](https://catrobat.atlassian.net/browse/PAINTROID-727), which aims to improve visual consistency by matching the gesture navigation bar color with the app's background.

## New Features and Enhancements
- The navigation bar color now dynamically matches the app's background using the current theme color.
## Refactorings and Bug Fixes
- Set SystemUiMode.edgeToEdge in main.dart to allow drawing behind system UI.
- Applied SystemUiOverlayStyle after the first frame in app.dart to properly apply the background color from the theme.

## Checklist

#### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Add the link to the ticket in Jira in the description of the PR
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines (Wiki)
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Add new information to the [Wiki](https://github.com/Catrobat/Paintroid-Flutter/wiki)



[PAINTROID-727]: https://catrobat.atlassian.net/browse/PAINTROID-727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ