### PR TITLE
PAINTROID-704 fix rate us warning

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -109,11 +109,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>LSApplicationQueriesSchemes</key>
-    <array>
-            <string>itms-beta</string>
-            <string>itms</string>
-    </array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>

--- a/lib/ui/pages/landing_page/components/main_overflow_menu.dart
+++ b/lib/ui/pages/landing_page/components/main_overflow_menu.dart
@@ -68,7 +68,6 @@ class _MainOverFlowMenuState extends ConsumerState<MainOverflowMenu>
           mode: LaunchMode.externalApplication,
         );
         if (!launched) {
-          // launchUrl returned false, meaning it failed to open the url
           logger.severe('Could not launch app store URL: $url');
         }
       }

--- a/lib/ui/pages/landing_page/components/main_overflow_menu.dart
+++ b/lib/ui/pages/landing_page/components/main_overflow_menu.dart
@@ -82,7 +82,7 @@ class _MainOverFlowMenuState extends ConsumerState<MainOverflowMenu>
     String version = packageInfo.version;
     switch (option) {
       case MainOverflowMenuOption.rate:
-        _openStore();
+        await _openStore();
         break;
       case MainOverflowMenuOption.help:
         if (mounted) {

--- a/lib/ui/pages/landing_page/components/main_overflow_menu.dart
+++ b/lib/ui/pages/landing_page/components/main_overflow_menu.dart
@@ -1,13 +1,15 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
-import 'package:launch_review_latest/launch_review_latest.dart';
 
 import 'package:paintroid/core/utils/open_url.dart';
 import 'package:paintroid/ui/shared/dialogs/about_dialog.dart';
 import 'package:paintroid/ui/shared/pop_menu_button.dart';
 import 'package:paintroid/ui/theme/theme.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 enum MainOverflowMenuOption {
   rate('Rate us!'),
@@ -50,12 +52,27 @@ class _MainOverFlowMenuState extends ConsumerState<MainOverflowMenu> {
     );
   }
 
+  void _openStore() {
+    if (Platform.isAndroid || Platform.isIOS) {
+      final appId = Platform.isAndroid ? androidAppId : iOSAppId;
+      final url = Uri.parse(
+        Platform.isAndroid
+            ? 'market://details?id=$appId'
+            : 'https://apps.apple.com/at/app/pocket-code/id1117935892',
+      );
+      launchUrl(
+        url,
+        mode: LaunchMode.externalApplication,
+      );
+    }
+  }
+
   Future<void> _handleSelectedOption(MainOverflowMenuOption option) async {
     PackageInfo packageInfo = await PackageInfo.fromPlatform();
     String version = packageInfo.version;
     switch (option) {
       case MainOverflowMenuOption.rate:
-        LaunchReviewLatest.launch(androidAppId: androidAppId, iOSAppId: iOSAppId);
+        _openStore();
         break;
       case MainOverflowMenuOption.help:
         if (mounted) {

--- a/lib/ui/pages/landing_page/components/main_overflow_menu.dart
+++ b/lib/ui/pages/landing_page/components/main_overflow_menu.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:paintroid/core/models/loggable_mixin.dart';
 
 import 'package:paintroid/core/utils/open_url.dart';
 import 'package:paintroid/ui/shared/dialogs/about_dialog.dart';
@@ -29,7 +30,8 @@ class MainOverflowMenu extends ConsumerStatefulWidget {
   ConsumerState<MainOverflowMenu> createState() => _MainOverFlowMenuState();
 }
 
-class _MainOverFlowMenuState extends ConsumerState<MainOverflowMenu> {
+class _MainOverFlowMenuState extends ConsumerState<MainOverflowMenu>
+    with LoggableMixin {
   final feedbackUrl = 'mailto:support-paintroid@catrobat.org';
   final iOSAppId = 'org.catrobat.paintroidflutter';
   final androidAppId = 'org.catrobat.paintroid';
@@ -52,18 +54,26 @@ class _MainOverFlowMenuState extends ConsumerState<MainOverflowMenu> {
     );
   }
 
-  void _openStore() {
-    if (Platform.isAndroid || Platform.isIOS) {
-      final appId = Platform.isAndroid ? androidAppId : iOSAppId;
-      final url = Uri.parse(
-        Platform.isAndroid
-            ? 'market://details?id=$appId'
-            : 'https://apps.apple.com/at/app/pocket-code/id1117935892',
-      );
-      launchUrl(
-        url,
-        mode: LaunchMode.externalApplication,
-      );
+  Future<void> _openStore() async {
+    try {
+      if (Platform.isAndroid || Platform.isIOS) {
+        final appId = Platform.isAndroid ? androidAppId : iOSAppId;
+        final url = Uri.parse(
+          Platform.isAndroid
+              ? 'market://details?id=$appId'
+              : 'https://apps.apple.com/app/$appId',
+        );
+        final launched = await launchUrl(
+          url,
+          mode: LaunchMode.externalApplication,
+        );
+        if (!launched) {
+          // launchUrl returned false, meaning it failed to open the url
+          logger.severe('Could not launch app store URL: $url');
+        }
+      }
+    } catch (err, stacktrace) {
+      logger.severe('Failed to open app store', err, stacktrace);
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -672,14 +672,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.9.0"
-  launch_review_latest:
-    dependency: "direct main"
-    description:
-      name: launch_review_latest
-      sha256: dd0f28a8612b10e550e44d45a0caa9559cf7a3b96a56249aaf3f24ee765ddbe9
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,6 @@ dependencies:
   toast: ^0.3.0
   oxidized: ^5.2.0
   flutter_svg: ^1.1.0
-  launch_review_latest: ^1.0.0
   package_info_plus: ^8.3.0
   filesize: ^2.0.1
   smooth_page_indicator: ^1.0.0+2

--- a/test/widget/landing_page/landing_page_test.dart
+++ b/test/widget/landing_page/landing_page_test.dart
@@ -134,6 +134,28 @@ void main() {
   );
 
   testWidgets(
+    'Should tap Rate us! option and handle it without crashing',
+    (tester) async {
+      when(database.projectDAO).thenReturn(dao);
+      when(dao.getProjects()).thenAnswer((_) => Future.value([]));
+
+      await tester.pumpWidget(sut);
+      await tester.pumpAndSettle();
+
+      final mainOverflowMenu = find.byType(MainOverflowMenu);
+      expect(mainOverflowMenu, findsOneWidget);
+
+      await tester.tap(mainOverflowMenu);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Rate us!'));
+      await tester.pumpAndSettle();
+
+      expect(mainOverflowMenu, findsOneWidget);
+    },
+  );
+
+  testWidgets(
     'Should have the two FABs',
     (tester) async {
       when(database.projectDAO).thenReturn(dao);


### PR DESCRIPTION
This PR fixes the warnings for deprecated APIs.

 [PAINTROID-704](https://catrobat.atlassian.net/browse/PAINTROID-704)

## Refactorings and Bug Fixes
- Fixed the "Rate Us" prompt to comply with Android guidelines.
- Removed deprecated or unnecessary code related to app review that was causing warnings.

## Checklist

### Your checklist for this pull request  
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title  
- [x] Add the link to the ticket in Jira in the description of the PR  
- [x] Include a summary of the changes plus the relevant context  
- [x] Choose the proper base branch (*develop*)  
- [x] Confirm that the changes follow the project’s coding guidelines (Wiki)  
- [x] Verify that the changes generate no compiler or linter warnings  
- [x] Perform a self-review of the changes  
- [x] Verify to commit no other files than the intentionally changed ones  
- [x] Include reasonable and readable tests verifying the added or changed behavior  
- [x] Confirm that new and existing tests pass locally  
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)  
- [x] Verify that your changes do not have any conflicts with the base branch  
- [x] After the PR, verify that all CI checks have passed  
- [ ] Add new information to the [Wiki](https://github.com/Catrobat/Paintroid-Flutter/wiki)


[PAINTROID-704]: https://catrobat.atlassian.net/browse/PAINTROID-704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ