### PR TITLE
[DEVOPS-849] Upload checksum of apk archive before upload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,13 +56,13 @@ jobs:
           sha256sum build/app/outputs/flutter-apk/flutter-paint-${{ github.event.number }}.zip > build/app/outputs/flutter-apk/checksum.txt
 
       - name: Upload APK ZIP
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: flutter-paint-apk-${{ github.event.number }}
           path: build/app/outputs/flutter-apk/flutter-paint-${{ github.event.number }}.zip
 
       - name: Upload Checksum
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: flutter-paint-checksum-${{ github.event.number }}
           path: build/app/outputs/flutter-apk/checksum.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,9 +46,23 @@ jobs:
           flutter build apk --release
           mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/flutter-paint-${{ github.event.number }}.apk
 
-      - name: Archive build artifacts
+      - name: Zip the APK
+        run: |
+          cd build/app/outputs/flutter-apk
+          zip flutter-paint-${{ github.event.number }}.zip flutter-paint-${{ github.event.number }}.apk
+
+      - name: Calculate ZIP SHA256 checksum
+        run: |
+          sha256sum build/app/outputs/flutter-apk/flutter-paint-${{ github.event.number }}.zip > build/app/outputs/flutter-apk/checksum.txt
+
+      - name: Upload APK ZIP
         uses: actions/upload-artifact@v4.3.3
         with:
           name: flutter-paint-apk-${{ github.event.number }}
-          path: |
-            build/app/outputs/flutter-apk/flutter-paint-${{ github.event.number }}.apk
+          path: build/app/outputs/flutter-apk/flutter-paint-${{ github.event.number }}.zip
+
+      - name: Upload Checksum
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: flutter-paint-checksum-${{ github.event.number }}
+          path: build/app/outputs/flutter-apk/checksum.txt


### PR DESCRIPTION
We should also calculate checksum of the apk archive before the upload and not only [after the upload](https://github.com/Catrobat/Paintroid-Flutter/actions/runs/16705099056/job/47282017736#step:12:22), so that it can be compared if the archive got corrupted during the upload.

https://catrobat.atlassian.net/browse/DEVOPS-849

Also see analysis on Slack.

## Checklist

#### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Add the link to the ticket in Jira in the description of the PR
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines (Wiki)
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Add new information to the [Wiki](https://github.com/Catrobat/Paintroid-Flutter/wiki)

