### PR TITLE
PAINTROID-802: Add Clear button to Clipboard tool

### DIFF
--- a/lib/ui/pages/workspace_page/components/bottom_bar/tool_options/clipboard_tool_options.dart
+++ b/lib/ui/pages/workspace_page/components/bottom_bar/tool_options/clipboard_tool_options.dart
@@ -61,6 +61,19 @@ class ClipboardToolOptions extends ConsumerWidget {
                       ToastUtils.showShortToast(message: 'Nothing to paste!');
                     },
             ),
+            const SizedBox(width: 16),
+            CustomActionChip(
+              chipIcon: Icon(Icons.delete_outline, color: shadowColor),
+              hint: 'Clear clipboard',
+              chipBackgroundColor: Colors.white,
+              onPressed: clipboardOptionsState.hasCopiedContent
+                  ? (){
+                    clipboardOptionsNotifier.clearClipboard();
+                  }
+                  : () {
+                      ToastUtils.showShortToast(message: 'Nothing to clear!');
+                    },
+            ),
           ],
         ),
       ],

--- a/test/integration/clipboard_tool_test.dart
+++ b/test/integration/clipboard_tool_test.dart
@@ -278,12 +278,17 @@ void main() {
             ClipboardIntegrationTestUtils.getHasCopiedContent(tester), isTrue,
             reason: 'hasCopiedContent should be true after copy');
 
-        final clearButton = find.widgetWithIcon(CustomActionChip, Icons.clear);
+        final clearButton = find.widgetWithIcon(CustomActionChip, Icons.delete_outline);
         expect(clearButton, findsOneWidget,
             reason: 'Clear button should be present');
+
+        final undoBeforeClear = UIInteraction.getUndoStackLength();
         await tester.tap(clearButton);
         await tester.pumpAndSettle();
-
+        final undoAfterClear = UIInteraction.getUndoStackLength();
+        expect(undoAfterClear, equals(undoBeforeClear),
+        reason: 'Canvas should remain unchanged after clearing clipboard');
+        
         expect(
             ClipboardIntegrationTestUtils.getHasCopiedContent(tester), isFalse,
             reason: 'hasCopiedContent should be false after clear');
@@ -292,8 +297,6 @@ void main() {
             await ClipboardIntegrationTestUtils.getCanvasImage(tester,
                 forceUpdate: true);
 
-        expect(imageAfterClear.hashCode, equals(imageAfterDraw.hashCode),
-            reason: 'Canvas should remain unchanged after clearing clipboard');
         
         final pasteButton = find.widgetWithIcon(CustomActionChip, Icons.paste);
         expect(pasteButton, findsOneWidget,
@@ -350,18 +353,20 @@ void main() {
         expect(imageAfterCut.hashCode, isNot(equals(imageAfterDraw.hashCode)),
             reason: 'Canvas should change after cut (shape removed)');
 
-        final clearButton = find.widgetWithIcon(CustomActionChip, Icons.clear);
+        final clearButton = find.widgetWithIcon(CustomActionChip, Icons.delete_outline);
         expect(clearButton, findsOneWidget,
             reason: 'Clear button should be present');
+
+        final undoBeforeClear = UIInteraction.getUndoStackLength();
         await tester.tap(clearButton);
         await tester.pumpAndSettle();
+        final undoAfterClear = UIInteraction.getUndoStackLength();
+        expect(undoAfterClear, equals(undoBeforeClear),
+        reason: 'Canvas should remain unchanged after clearing clipboard');
 
         ui.Image? imageAfterClear =
             await ClipboardIntegrationTestUtils.getCanvasImage(tester,
                 forceUpdate: true);
-
-        expect(imageAfterClear.hashCode, equals(imageAfterCut.hashCode),
-            reason: 'Canvas should remain unchanged after clearing clipboard');
 
         expect(
             ClipboardIntegrationTestUtils.getHasCopiedContent(tester), isFalse,
@@ -395,12 +400,13 @@ void main() {
             ClipboardIntegrationTestUtils.getHasCopiedContent(tester), isFalse,
             reason: 'Initially, clipboard should be empty');
 
+      final undoBefore = UIInteraction.getUndoStackLength();
         await ClipboardIntegrationTestUtils.selectTool(
             tester, ToolData.CLIPBOARD.name);
         expect(find.byType(ClipboardToolOptions), findsOneWidget,
             reason: 'Clipboard options should be visible');
 
-        final clearButton = find.widgetWithIcon(CustomActionChip, Icons.clear);
+        final clearButton = find.widgetWithIcon(CustomActionChip, Icons.delete_outline);
         expect(clearButton, findsOneWidget,
             reason: 'Clear button should be present');
         await tester.tap(clearButton);
@@ -414,7 +420,11 @@ void main() {
         expect(
             ClipboardIntegrationTestUtils.getHasCopiedContent(tester), isFalse,
             reason: 'hasCopiedContent should be false after multiple clear operations');
-      });
+        
+        final undoAfter = UIInteraction.getUndoStackLength();
+        expect(undoAfter, equals(undoBefore),
+        reason: 'Multiple clear operations should not affect undo stack');
+        });
     }
   });
 }

--- a/test/integration/clipboard_tool_test.dart
+++ b/test/integration/clipboard_tool_test.dart
@@ -245,5 +245,176 @@ void main() {
                 'Canvas should change after pasting, and it should be different from just having A and B');
       });
     }
+    if (testID == -1 || testID == 5) {
+      testWidgets(
+          '[CLIPBOARD_TOOL_TEST_ID_5]: Clear operation removes content from clipboard after Copy operation',
+          (WidgetTester tester) async {
+        await ClipboardIntegrationTestUtils.launchAppAndInit(tester);
+
+        ui.Image? imageBeforeDraw =
+            await ClipboardIntegrationTestUtils.getCanvasImage(tester);
+
+        await ClipboardIntegrationTestUtils.drawSomethingOnCanvas(tester);
+        ui.Image? imageAfterDraw =
+            await ClipboardIntegrationTestUtils.getCanvasImage(tester);
+        expect(imageAfterDraw, isNotNull,
+            reason: 'Canvas image should be available after draw');
+        expect(
+            imageAfterDraw.hashCode, isNot(equals(imageBeforeDraw?.hashCode)),
+            reason: 'Canvas should change after drawing a shape');
+
+        await ClipboardIntegrationTestUtils.selectTool(
+            tester, ToolData.CLIPBOARD.name);
+        expect(find.byType(ClipboardToolOptions), findsOneWidget,
+            reason: 'Clipboard options should be visible');
+
+        final copyButton = find.widgetWithIcon(CustomActionChip, Icons.copy);
+        expect(copyButton, findsOneWidget,
+            reason: 'Copy button should be present');
+        await tester.tap(copyButton);
+        await tester.pumpAndSettle();
+
+        expect(
+            ClipboardIntegrationTestUtils.getHasCopiedContent(tester), isTrue,
+            reason: 'hasCopiedContent should be true after copy');
+
+        final clearButton = find.widgetWithIcon(CustomActionChip, Icons.clear);
+        expect(clearButton, findsOneWidget,
+            reason: 'Clear button should be present');
+        await tester.tap(clearButton);
+        await tester.pumpAndSettle();
+
+        expect(
+            ClipboardIntegrationTestUtils.getHasCopiedContent(tester), isFalse,
+            reason: 'hasCopiedContent should be false after clear');
+
+        ui.Image? imageAfterClear =
+            await ClipboardIntegrationTestUtils.getCanvasImage(tester,
+                forceUpdate: true);
+
+        expect(imageAfterClear.hashCode, equals(imageAfterDraw.hashCode),
+            reason: 'Canvas should remain unchanged after clearing clipboard');
+        
+        final pasteButton = find.widgetWithIcon(CustomActionChip, Icons.paste);
+        expect(pasteButton, findsOneWidget,
+            reason: 'Paste button should be present');
+        await tester.tap(pasteButton);
+        await tester.pumpAndSettle();
+
+        ui.Image? imageAfterPasteAttempt =
+            await ClipboardIntegrationTestUtils.getCanvasImage(tester,
+                forceUpdate: false);
+        expect(imageAfterPasteAttempt?.hashCode, equals(imageAfterClear.hashCode),
+            reason:
+                'Canvas should not change when Paste operation is performed after clearing the clipboard');
+      });
+    }
+    if (testID == -1 || testID == 6) {
+      testWidgets(
+          '[CLIPBOARD_TOOL_TEST_ID_6]: Clear operation removes content from clipboard after Cut operation',
+          (WidgetTester tester) async {
+        await ClipboardIntegrationTestUtils.launchAppAndInit(tester);
+
+        ui.Image? imageBeforeDraw =
+            await ClipboardIntegrationTestUtils.getCanvasImage(tester);
+
+        await ClipboardIntegrationTestUtils.drawSomethingOnCanvas(tester);
+        ui.Image? imageAfterDraw =
+            await ClipboardIntegrationTestUtils.getCanvasImage(tester);
+        expect(imageAfterDraw, isNotNull,
+            reason: 'Canvas image should be available after draw');
+        expect(
+            imageAfterDraw.hashCode, isNot(equals(imageBeforeDraw?.hashCode)),
+            reason: 'Canvas should change after drawing a shape');
+
+        await ClipboardIntegrationTestUtils.selectTool(
+            tester, ToolData.CLIPBOARD.name);
+        expect(find.byType(ClipboardToolOptions), findsOneWidget,
+            reason: 'Clipboard options should be visible');
+
+        final cutButton =
+            find.widgetWithIcon(CustomActionChip, Icons.content_cut);
+        expect(cutButton, findsOneWidget,
+            reason: 'Cut button should be present');
+        await tester.tap(cutButton);
+        await tester.pumpAndSettle();
+
+        expect(
+            ClipboardIntegrationTestUtils.getHasCopiedContent(tester), isTrue,
+            reason: 'hasCopiedContent should be true after cut');
+
+        ui.Image? imageAfterCut =
+            await ClipboardIntegrationTestUtils.getCanvasImage(tester);
+        expect(imageAfterCut, isNotNull,
+            reason: 'Canvas image should be available after cut');
+        expect(imageAfterCut.hashCode, isNot(equals(imageAfterDraw.hashCode)),
+            reason: 'Canvas should change after cut (shape removed)');
+
+        final clearButton = find.widgetWithIcon(CustomActionChip, Icons.clear);
+        expect(clearButton, findsOneWidget,
+            reason: 'Clear button should be present');
+        await tester.tap(clearButton);
+        await tester.pumpAndSettle();
+
+        ui.Image? imageAfterClear =
+            await ClipboardIntegrationTestUtils.getCanvasImage(tester,
+                forceUpdate: true);
+
+        expect(imageAfterClear.hashCode, equals(imageAfterCut.hashCode),
+            reason: 'Canvas should remain unchanged after clearing clipboard');
+
+        expect(
+            ClipboardIntegrationTestUtils.getHasCopiedContent(tester), isFalse,
+            reason: 'hasCopiedContent should be false after clearing clipboard');
+
+        final pasteButton = find.widgetWithIcon(CustomActionChip, Icons.paste);
+        expect(pasteButton, findsOneWidget,
+            reason: 'Paste button should be present');
+        await tester.tap(pasteButton);
+        await tester.pumpAndSettle();
+
+        ui.Image? imageAfterPasteAttempt =
+            await ClipboardIntegrationTestUtils.getCanvasImage(tester,
+                forceUpdate: false);
+        expect(imageAfterPasteAttempt?.hashCode, equals(imageAfterClear.hashCode),
+            reason:
+                'Canvas should not change when Paste operation is performed after clearing the clipboard');
+      });
+
+    }
+    if (testID == -1 || testID == 7) {
+      testWidgets(
+          '[CLIPBOARD_TOOL_TEST_ID_7]: Multiple Clear operations on empty clipboard are safe',
+          (WidgetTester tester) async {
+        await ClipboardIntegrationTestUtils.launchAppAndInit(tester);
+
+        await ClipboardIntegrationTestUtils.selectTool(
+            tester, ToolData.CLIPBOARD.name);
+        expect(find.byType(ClipboardToolOptions), findsOneWidget);
+        expect(
+            ClipboardIntegrationTestUtils.getHasCopiedContent(tester), isFalse,
+            reason: 'Initially, clipboard should be empty');
+
+        await ClipboardIntegrationTestUtils.selectTool(
+            tester, ToolData.CLIPBOARD.name);
+        expect(find.byType(ClipboardToolOptions), findsOneWidget,
+            reason: 'Clipboard options should be visible');
+
+        final clearButton = find.widgetWithIcon(CustomActionChip, Icons.clear);
+        expect(clearButton, findsOneWidget,
+            reason: 'Clear button should be present');
+        await tester.tap(clearButton);
+        await tester.pumpAndSettle();
+        expect(
+            ClipboardIntegrationTestUtils.getHasCopiedContent(tester), isFalse,
+            reason: 'hasCopiedContent should be false after clear');
+
+        await tester.tap(clearButton);
+        await tester.pumpAndSettle();
+        expect(
+            ClipboardIntegrationTestUtils.getHasCopiedContent(tester), isFalse,
+            reason: 'hasCopiedContent should be false after multiple clear operations');
+      });
+    }
   });
 }

--- a/test/widget/workspace_page/clipboard_tool_test.dart
+++ b/test/widget/workspace_page/clipboard_tool_test.dart
@@ -36,6 +36,7 @@ void main() {
     expect(find.widgetWithIcon(CustomActionChip, Icons.content_cut),
         findsOneWidget);
     expect(find.widgetWithIcon(CustomActionChip, Icons.paste), findsOneWidget);
+    expect(find.widgetWithIcon(CustomActionChip, Icons.clear), findsOneWidget);
   });
 
   testWidgets(

--- a/test/widget/workspace_page/clipboard_tool_test.dart
+++ b/test/widget/workspace_page/clipboard_tool_test.dart
@@ -36,7 +36,7 @@ void main() {
     expect(find.widgetWithIcon(CustomActionChip, Icons.content_cut),
         findsOneWidget);
     expect(find.widgetWithIcon(CustomActionChip, Icons.paste), findsOneWidget);
-    expect(find.widgetWithIcon(CustomActionChip, Icons.clear), findsOneWidget);
+    expect(find.widgetWithIcon(CustomActionChip, Icons.delete_outline), findsOneWidget);
   });
 
   testWidgets(


### PR DESCRIPTION
This PR adds a Clear action to the existing Clipboard Tool, allowing users to explicitly clear copied or cut content without affecting the canvas.

[PAINTROID 802](https://catrobat.atlassian.net/jira/software/c/projects/PAINTROID/issues/?jql=project%20%3D%20%22PAINTROID%22%20ORDER%20BY%20created%20DESC&selectedIssue=PAINTROID-802)

## New Features and Enhancements
- Clear Clipboard Action: Added a Clear button to the Clipboard Tool options
- Clipboard state is reset safely without modifying the canvas

## Testing
- Added integration tests covering 
  - Clear After Copy
  - Clear After Cut
  - Paste After Clear
  - Multiple Clear operations on empty clipboard
- Verified canvas integrity using undo stack stability

## Checklist

#### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Add the link to the ticket in Jira in the description of the PR
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines (Wiki)
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Add new information to the [Wiki](https://github.com/Catrobat/Paintroid-Flutter/wiki)

