### PR TITLE
PAINTROID-799 Add white background to color preview for transparency

### DIFF
--- a/lib/ui/pages/workspace_page/components/bottom_bar/bottom_nav_bar.dart
+++ b/lib/ui/pages/workspace_page/components/bottom_bar/bottom_nav_bar.dart
@@ -43,18 +43,21 @@ class BottomNavBar extends ConsumerWidget {
           ),
           NavigationDestination(
             label: localizations.color,
-            icon: InkWell(
-              child: Container(
-                height: 24.0,
-                width: 24.0,
-                decoration: BoxDecoration(
-                  color: currentPaint.color,
-                  border: Border.all(
-                    color: PaintroidTheme.of(context).onSurfaceColor,
-                    width: 1.4,
-                  ),
-                  borderRadius: BorderRadius.circular(2.0),
+            icon: Container(
+
+              height: 24.0,
+              width: 24.0,
+              clipBehavior: Clip.antiAlias,
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(2.0),
+                border: Border.all(
+                  color: PaintroidTheme.of(context).onSurfaceColor,
+                  width: 1.4,
                 ),
+              ),
+              child: Container(
+                color: currentPaint.color,
               ),
             ),
           ),
@@ -72,16 +75,15 @@ class BottomNavBar extends ConsumerWidget {
       toolBoxStateProvider.select((value) => value.currentTool.type),
     );
 
-    final currentToolData = ToolData.allToolsData.firstWhere(
+    return ToolData.allToolsData.firstWhere(
       (toolData) => toolData.type == currentToolType,
       orElse: () => ToolData.BRUSH,
     );
-    return currentToolData;
   }
 }
 
 void _onNavigationItemSelected(int index, BuildContext context, WidgetRef ref) {
-  BottomNavBarItem item = BottomNavBarItem.values[index];
+  final BottomNavBarItem item = BottomNavBarItem.values[index];
   switch (item) {
     case BottomNavBarItem.TOOLS:
       _showToolBottomSheet(context);
@@ -98,7 +100,7 @@ void _onNavigationItemSelected(int index, BuildContext context, WidgetRef ref) {
 }
 
 void _showToolBottomSheet(BuildContext context) {
-  double screenHeight = MediaQuery.of(context).size.height;
+  final double screenHeight = MediaQuery.of(context).size.height;
   showModalBottomSheet(
     context: context,
     builder: (BuildContext context) => SizedBox(

--- a/packages/colorpicker/lib/src/components/color_square.dart
+++ b/packages/colorpicker/lib/src/components/color_square.dart
@@ -11,16 +11,21 @@ class ColorSquare extends ConsumerWidget {
   final Color color;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return GestureDetector(
-      onTap: () {
-        ref.read(colorPickerStateProvider.notifier).updateColor(color);
-      },
-      child: Container(
-        decoration: BoxDecoration(
-          color: color,
+Widget build(BuildContext context, WidgetRef ref) {
+  return GestureDetector(
+    onTap: () {
+      ref.read(colorPickerStateProvider.notifier).updateColor(color);
+    },
+    child: Stack( 
+      children: [
+        Container(color: Colors.white),
+        Container(
+          decoration: BoxDecoration(
+            color: color, 
+          ),
         ),
-      ),
-    );
-  }
+      ],
+    ),
+  );
+}
 }

--- a/test/utils/bottom_nav_bar_interactions.dart
+++ b/test/utils/bottom_nav_bar_interactions.dart
@@ -32,7 +32,7 @@ class BottomNavBarInteractions {
 
     final toolIconButton = _findIconButtonWithLabel(toolData.name);
     expect(toolIconButton, findsOneWidget);
-
+    
     await _tester.tap(toolIconButton);
     await _tester.pumpAndSettle();
     return this;
@@ -49,10 +49,10 @@ class BottomNavBarInteractions {
 
   Future<BottomNavBarInteractions> selectColor(Color color) async {
     await openColorPicker();
-
-    final colorButton = _findButtonWithColor(color);
+    
+        final colorButton = _findButtonWithColor(color);
     expect(colorButton, findsOneWidget);
-
+    
     await _tester.tap(colorButton);
     await _tester.pumpAndSettle();
     final applyButton = find.descendant(
@@ -71,29 +71,22 @@ class BottomNavBarInteractions {
   Future<BottomNavBarInteractions> checkActiveColor(Color color) async {
     final thirdNavDestination = find.byType(NavigationDestination).at(2);
     final activeColor = find.descendant(
-        of: thirdNavDestination,
-        matching: find.byWidgetPredicate((Widget widget) =>
-            widget is InkWell &&
-            widget.child is Container &&
-            (widget.child as Container).decoration is BoxDecoration &&
-            ((widget.child as Container).decoration as BoxDecoration)
-                    .color
-                    ?.toValue() ==
-                color.toValue()));
-
+      of: thirdNavDestination,
+      matching: find.byWidgetPredicate((Widget widget) =>
+          widget is Container && widget.color?.toValue() == color.toValue()),
+    );
     expect(activeColor, findsOneWidget);
     return this;
   }
 
   Finder _findButtonWithColor(Color color) {
     return find.descendant(
-      of: find.byWidgetPredicate((Widget widget) =>
-          widget is GestureDetector &&
-          widget.child is Container &&
-          (widget.child as Container).decoration is BoxDecoration &&
-          ((widget.child as Container).decoration as BoxDecoration).color ==
-              color),
-      matching: find.byType(Container),
+      of: find.byType(Stack),
+      matching: find.byWidgetPredicate((Widget widget) =>
+          widget is Container &&
+          widget.decoration is BoxDecoration &&
+          (widget.decoration as BoxDecoration).color?.toValue() ==
+              color.toValue()),
     );
   }
 

--- a/test/widget/workspace_page/bottom_control_navigation_bar_test.dart
+++ b/test/widget/workspace_page/bottom_control_navigation_bar_test.dart
@@ -171,8 +171,8 @@ void main() {
       expect(animatedOpacityWidget.opacity, equals(VISIBLE));
     });
   });
-
-  group('BottomNavBarItem.COLOR', () {
+  
+group('BottomNavBarItem.COLOR', () {
     testWidgets('Test if color changes on selection',
         (WidgetTester tester) async {
       const blueColor = Color(0xff0073cc);
@@ -183,6 +183,22 @@ void main() {
       await bottomNavBarInteractions.selectColor(blueColor).then(
           (bottomNavBarInteractions) =>
               bottomNavBarInteractions.checkActiveColor(blueColor));
+    });
+
+    testWidgets('Verify color preview has a white background layer for transparency',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(sut);
+
+      final thirdNavDestination = find.byType(NavigationDestination).at(2);
+      final whiteBackgroundFinder = find.descendant(
+        of: thirdNavDestination,
+        matching: find.byWidgetPredicate((widget) =>
+            widget is Container &&
+            widget.decoration is BoxDecoration &&
+            (widget.decoration as BoxDecoration).color == Colors.white),
+      );
+
+      expect(whiteBackgroundFinder, findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
This pull request addresses the visibility issue of transparent colors in the user interface. Previously, semi-transparent colors in the bottom navigation bar and color picker blended directly with the application's grey/dark theme, leading to inaccurate previews or "muddy" colors.

This is a partial fix for Jira ticket #799.
New Features and Enhancements

    Enhanced Color Accuracy: Users can now see a true representation of a color's transparency against a neutral white base.

Refactorings and Bug Fixes

    Bottom Navigation Bar: Wrapped the color preview square in a white background container to act as a neutral base for transparency.

    Color Picker Package: Updated the ColorSquare component with a Stack containing a white background layer.

    Test Infrastructure: Updated BottomNavBarInteractions and added a regression test in bottom_control_navigation_bar_test.dart to verify the white background presence.

Checklist

    [x] Include the name of the Jira ticket in the PR’s title

    [x] Add the link to the ticket in Jira in the description of the PR (#799)

    [x] Include a summary of the changes plus the relevant context

    [x] Choose the proper base branch (develop)

    [x] Confirm that the changes follow the project’s coding guidelines

    [x] Verify that the changes generate no compiler or linter warnings

    [x] Perform a self-review of the changes

    [x] Verify to commit no other files than the intentionally changed ones

    [x] Include reasonable and readable tests verifying the added behavior

    [x] Confirm that new and existing tests pass locally

    [x] Check that the commits’ message style matches the project’s guideline

    [x] Verify that your changes do not have any conflicts with the base branch