### PR TITLE
PAINTROID-799 Fix transparency visibility and watercolor zoom darkening

### DIFF
--- a/lib/ui/pages/workspace_page/components/bottom_bar/bottom_nav_bar.dart
+++ b/lib/ui/pages/workspace_page/components/bottom_bar/bottom_nav_bar.dart
@@ -43,18 +43,21 @@ class BottomNavBar extends ConsumerWidget {
           ),
           NavigationDestination(
             label: localizations.color,
-            icon: InkWell(
-              child: Container(
-                height: 24.0,
-                width: 24.0,
-                decoration: BoxDecoration(
-                  color: currentPaint.color,
-                  border: Border.all(
-                    color: PaintroidTheme.of(context).onSurfaceColor,
-                    width: 1.4,
-                  ),
-                  borderRadius: BorderRadius.circular(2.0),
+            icon: Container(
+
+              height: 24.0,
+              width: 24.0,
+              clipBehavior: Clip.antiAlias,
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(2.0),
+                border: Border.all(
+                  color: PaintroidTheme.of(context).onSurfaceColor,
+                  width: 1.4,
                 ),
+              ),
+              child: Container(
+                color: currentPaint.color,
               ),
             ),
           ),
@@ -72,16 +75,15 @@ class BottomNavBar extends ConsumerWidget {
       toolBoxStateProvider.select((value) => value.currentTool.type),
     );
 
-    final currentToolData = ToolData.allToolsData.firstWhere(
+    return ToolData.allToolsData.firstWhere(
       (toolData) => toolData.type == currentToolType,
       orElse: () => ToolData.BRUSH,
     );
-    return currentToolData;
   }
 }
 
 void _onNavigationItemSelected(int index, BuildContext context, WidgetRef ref) {
-  BottomNavBarItem item = BottomNavBarItem.values[index];
+  final BottomNavBarItem item = BottomNavBarItem.values[index];
   switch (item) {
     case BottomNavBarItem.TOOLS:
       _showToolBottomSheet(context);
@@ -98,7 +100,7 @@ void _onNavigationItemSelected(int index, BuildContext context, WidgetRef ref) {
 }
 
 void _showToolBottomSheet(BuildContext context) {
-  double screenHeight = MediaQuery.of(context).size.height;
+  final double screenHeight = MediaQuery.of(context).size.height;
   showModalBottomSheet(
     context: context,
     builder: (BuildContext context) => SizedBox(

--- a/lib/ui/pages/workspace_page/components/drawing_surface/drawing_canvas.dart
+++ b/lib/ui/pages/workspace_page/components/drawing_surface/drawing_canvas.dart
@@ -25,6 +25,8 @@ class _DrawingCanvasState extends ConsumerState<DrawingCanvas> {
   final _transformationController = TransformationController();
   var _pointersOnScreen = 0;
   var _isZooming = false;
+  var _hasActiveDrawing = false; 
+  
   Offset _lastPointerUpPosition = Offset.zero;
 
   void _resetCanvasScale({bool fitToScreen = false}) =>
@@ -49,6 +51,7 @@ class _DrawingCanvasState extends ConsumerState<DrawingCanvas> {
     _pointersOnScreen++;
     if (_pointersOnScreen >= 2) {
       _isZooming = true;
+      _hasActiveDrawing = false;
       _toolBoxStateNotifier.didSwitchToZooming();
     }
   }
@@ -66,24 +69,24 @@ class _DrawingCanvasState extends ConsumerState<DrawingCanvas> {
   }
 
   void _onInteractionStart(ScaleStartDetails details) {
-    if (!_isZooming) {
-      if (details.pointerCount == 1) {
-        _toolBoxStateNotifier.didTapDown(_globalToCanvas(details.focalPoint));
-      }
+  
+    if (!_isZooming && details.pointerCount == 1) {
+      _hasActiveDrawing = true;
+      _toolBoxStateNotifier.didTapDown(_globalToCanvas(details.focalPoint));
     }
   }
 
   void _onInteractionUpdate(ScaleUpdateDetails details) {
-    if (!_isZooming) {
-      if (details.pointerCount == 1) {
-        _toolBoxStateNotifier.didDrag(_globalToCanvas(details.focalPoint));
-        ref.read(canvasPainterProvider.notifier).repaint();
-      }
+  
+    if (_hasActiveDrawing) {
+      _toolBoxStateNotifier.didDrag(_globalToCanvas(details.focalPoint));
+      ref.read(canvasPainterProvider.notifier).repaint();
     }
   }
 
   void _onInteractionEnd(ScaleEndDetails details) {
-    if (!_isZooming) {
+ 
+    if (_hasActiveDrawing) {
       _toolBoxStateNotifier.didTapUp(_globalToCanvas(_lastPointerUpPosition));
       ref.read(canvasPainterProvider.notifier).repaint();
       final currentTool = ref.read(toolBoxStateProvider).currentTool;
@@ -95,6 +98,7 @@ class _DrawingCanvasState extends ConsumerState<DrawingCanvas> {
           _canvasStateNotifier.updateCachedImage();
           break;
       }
+      _hasActiveDrawing = false;
     }
   }
 

--- a/packages/colorpicker/lib/src/components/color_square.dart
+++ b/packages/colorpicker/lib/src/components/color_square.dart
@@ -11,16 +11,21 @@ class ColorSquare extends ConsumerWidget {
   final Color color;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return GestureDetector(
-      onTap: () {
-        ref.read(colorPickerStateProvider.notifier).updateColor(color);
-      },
-      child: Container(
-        decoration: BoxDecoration(
-          color: color,
+Widget build(BuildContext context, WidgetRef ref) {
+  return GestureDetector(
+    onTap: () {
+      ref.read(colorPickerStateProvider.notifier).updateColor(color);
+    },
+    child: Stack( 
+      children: [
+        Container(color: Colors.white),
+        Container(
+          decoration: BoxDecoration(
+            color: color, 
+          ),
         ),
-      ),
-    );
-  }
+      ],
+    ),
+  );
+}
 }

--- a/test/unit/tools/watercolor_tool_test.dart
+++ b/test/unit/tools/watercolor_tool_test.dart
@@ -89,4 +89,13 @@ void main() {
   test('Should return WATERCOLOR as ToolType', () {
     expect(sut.type, ToolType.WATERCOLOR);
   });
+  test('WatercolorTool paint should maintain constant alpha and use correct blend mode', () {
+  final basePaint = Paint()..color = const Color.fromARGB(100, 255, 0, 0);
+  
+  sut.onDown(Offset.zero, basePaint);
+  final command = sut.commandManager.undoStack.first as PathCommand;
+  
+  expect(command.paint.color.alpha, equals(100));
+  expect(command.paint.blendMode, equals(BlendMode.srcOver));
+});
 }

--- a/test/utils/bottom_nav_bar_interactions.dart
+++ b/test/utils/bottom_nav_bar_interactions.dart
@@ -32,7 +32,7 @@ class BottomNavBarInteractions {
 
     final toolIconButton = _findIconButtonWithLabel(toolData.name);
     expect(toolIconButton, findsOneWidget);
-
+    
     await _tester.tap(toolIconButton);
     await _tester.pumpAndSettle();
     return this;
@@ -49,10 +49,10 @@ class BottomNavBarInteractions {
 
   Future<BottomNavBarInteractions> selectColor(Color color) async {
     await openColorPicker();
-
-    final colorButton = _findButtonWithColor(color);
+    
+        final colorButton = _findButtonWithColor(color);
     expect(colorButton, findsOneWidget);
-
+    
     await _tester.tap(colorButton);
     await _tester.pumpAndSettle();
     final applyButton = find.descendant(
@@ -71,29 +71,22 @@ class BottomNavBarInteractions {
   Future<BottomNavBarInteractions> checkActiveColor(Color color) async {
     final thirdNavDestination = find.byType(NavigationDestination).at(2);
     final activeColor = find.descendant(
-        of: thirdNavDestination,
-        matching: find.byWidgetPredicate((Widget widget) =>
-            widget is InkWell &&
-            widget.child is Container &&
-            (widget.child as Container).decoration is BoxDecoration &&
-            ((widget.child as Container).decoration as BoxDecoration)
-                    .color
-                    ?.toValue() ==
-                color.toValue()));
-
+      of: thirdNavDestination,
+      matching: find.byWidgetPredicate((Widget widget) =>
+          widget is Container && widget.color?.toValue() == color.toValue()),
+    );
     expect(activeColor, findsOneWidget);
     return this;
   }
 
   Finder _findButtonWithColor(Color color) {
     return find.descendant(
-      of: find.byWidgetPredicate((Widget widget) =>
-          widget is GestureDetector &&
-          widget.child is Container &&
-          (widget.child as Container).decoration is BoxDecoration &&
-          ((widget.child as Container).decoration as BoxDecoration).color ==
-              color),
-      matching: find.byType(Container),
+      of: find.byType(Stack),
+      matching: find.byWidgetPredicate((Widget widget) =>
+          widget is Container &&
+          widget.decoration is BoxDecoration &&
+          (widget.decoration as BoxDecoration).color?.toValue() ==
+              color.toValue()),
     );
   }
 

--- a/test/widget/workspace_page/bottom_control_navigation_bar_test.dart
+++ b/test/widget/workspace_page/bottom_control_navigation_bar_test.dart
@@ -171,8 +171,8 @@ void main() {
       expect(animatedOpacityWidget.opacity, equals(VISIBLE));
     });
   });
-
-  group('BottomNavBarItem.COLOR', () {
+  
+group('BottomNavBarItem.COLOR', () {
     testWidgets('Test if color changes on selection',
         (WidgetTester tester) async {
       const blueColor = Color(0xff0073cc);
@@ -183,6 +183,22 @@ void main() {
       await bottomNavBarInteractions.selectColor(blueColor).then(
           (bottomNavBarInteractions) =>
               bottomNavBarInteractions.checkActiveColor(blueColor));
+    });
+
+    testWidgets('Verify color preview has a white background layer for transparency',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(sut);
+
+      final thirdNavDestination = find.byType(NavigationDestination).at(2);
+      final whiteBackgroundFinder = find.descendant(
+        of: thirdNavDestination,
+        matching: find.byWidgetPredicate((widget) =>
+            widget is Container &&
+            widget.decoration is BoxDecoration &&
+            (widget.decoration as BoxDecoration).color == Colors.white),
+      );
+
+      expect(whiteBackgroundFinder, findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
This pull request addresses two distinct UI/UX issues related to transparency and rendering. First, it improves the visibility of transparent colors in the UI by adding a neutral background. Second, it resolves a bug where watercolor strokes would stack opacity and darken whenever the user zoomed or panned the canvas.

Jira Ticket: [PAINTROID-799](https://catrobat.atlassian.net/browse/PAINTROID-799)

New Features and Enhancements

    (None)

Refactorings and Bug Fixes

    Transparency Visibility Fix: Wrapped the color preview squares in the Bottom Navigation Bar and the ColorPicker package with a white background layer to provide a neutral reference for semi-transparent colors.

    Watercolor Darkening Fix: Introduced a _hasActiveDrawing flag in the DrawingCanvas to ensure the image cache is only updated after a valid drawing gesture. This prevents "double-painting" the last command during zoom and pan interactions.

    Test Infrastructure: Added a regression test in bottom_control_navigation_bar_test.dart and a unit test in watercolor_tool_test.dart to verify constant alpha maintenance.

Checklist
Your checklist for this pull request

    [x] Include the name of the Jira ticket in the PR’s title

    [x] Add the link to the ticket in Jira in the description of the PR

    [x] Include a summary of the changes plus the relevant context

    [x] Choose the proper base branch (develop)

    [x] Confirm that the changes follow the project’s coding guidelines (Wiki)

    [x] Verify that the changes generate no compiler or linter warnings

    [x] Perform a self-review of the changes

    [x] Verify to commit no other files than the intentionally changed ones

    [x] Include reasonable and readable tests verifying the added or changed behavior

    [x] Confirm that new and existing tests pass locally

    [x] Check that the commits’ message style matches the project’s guideline

    [x] Verify that your changes do not have any conflicts with the base branch

    [ ] After the PR, verify that all CI checks have passed

    [ ] Add new information to the Wiki

[PAINTROID-799]: https://catrobat.atlassian.net/browse/PAINTROID-799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ