### PR TITLE
PAINTROID-XXX Fix disabled color not applied to ActionButton

### DIFF
--- a/lib/ui/shared/action_button.dart
+++ b/lib/ui/shared/action_button.dart
@@ -23,8 +23,9 @@ class ActionButton extends StatelessWidget {
         key: ValueKey(valueKey),
         icon: Icon(icon),
         onPressed: onPressed,
-        disabledColor: PaintroidTheme.of(context).onSurfaceColor
-          ..withValues(alpha: 0.4),
+        disabledColor: PaintroidTheme.of(context)
+            .onSurfaceColor
+            .withValues(alpha: 0.4),
         color: PaintroidTheme.of(context).onSurfaceColor,
       ),
     );


### PR DESCRIPTION
Related Jira: PAINTROID-XXX
Jira link: N/A

## Refactorings and Bug Fixes
Fix disabled color not applied to ActionButton when onPressed is null due to incorrect cascade usage on immutable Color.

## Checklist

#### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Add the link to the ticket in Jira in the description of the PR
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines (Wiki)
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Add new information to the [Wiki](https://github.com/Catrobat/Paintroid-Flutter/wiki)

## Demo
- Current behavior
- https://github.com/user-attachments/assets/7e04b4fb-a377-47ab-9f39-db99179ba56d

- Expected outcome
- https://github.com/user-attachments/assets/c5306aa2-9229-42eb-b0cb-71a33c9a60bf





