### PR TITLE
feat: add sharing of the current canvas as a PNG image.

### DIFF
--- a/lib/core/localization/app_localizations.dart
+++ b/lib/core/localization/app_localizations.dart
@@ -123,6 +123,12 @@ abstract class AppLocalizations {
   /// **'Save project'**
   String get saveProject;
 
+  /// No description provided for @saveProject.
+  ///
+  /// In en, this message translates to:
+  /// **'Share Image'**
+  String get shareImage;
+
   /// No description provided for @tools.
   ///
   /// In en, this message translates to:

--- a/lib/core/localization/app_localizations_en.dart
+++ b/lib/core/localization/app_localizations_en.dart
@@ -35,4 +35,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get save => 'Save';
+
+  @override
+  String get shareImage => 'Share Image';
 }

--- a/lib/core/providers/object/io_handler.dart
+++ b/lib/core/providers/object/io_handler.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
-
+import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:oxidized/oxidized.dart';
@@ -26,6 +26,7 @@ import 'package:paintroid/ui/shared/dialogs/discard_changes_dialog.dart';
 import 'package:paintroid/ui/shared/dialogs/load_image_dialog.dart';
 import 'package:paintroid/ui/shared/dialogs/save_image_dialog.dart';
 import 'package:paintroid/ui/utils/toast_utils.dart';
+import 'package:share_plus/share_plus.dart';
 
 class IOHandler {
   final Ref ref;
@@ -196,6 +197,22 @@ class IOHandler {
         return false;
       },
     );
+  }
+
+  Future<void> shareImage() async {
+    final image = await ref
+        .read(RenderImageForExport.provider)
+        .call();
+
+    final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
+    final bytes = byteData!.buffer.asUint8List();
+
+    final XFile file = XFile.fromData(
+      bytes,
+      mimeType: 'image/png',
+      name: 'drawing.png',
+    );
+    Share.shareXFiles([file]);
   }
 
   Future<String?> getPreviewPath(ImageMetaData imageData) async {

--- a/lib/ui/pages/workspace_page/components/top_bar/overflow_menu.dart
+++ b/lib/ui/pages/workspace_page/components/top_bar/overflow_menu.dart
@@ -21,6 +21,7 @@ enum OverflowMenuOption {
   saveImage,
   saveProject,
   loadImage,
+  shareImage,
   newImage;
 
   String localizedLabel(BuildContext context) {
@@ -36,6 +37,8 @@ enum OverflowMenuOption {
         return localizations.newImage;
       case OverflowMenuOption.saveProject:
         return localizations.saveProject;
+      case OverflowMenuOption.shareImage:
+        return localizations.shareImage;
     }
   }
 }
@@ -82,6 +85,9 @@ class _OverflowMenuState extends ConsumerState<OverflowMenu> {
         break;
       case OverflowMenuOption.newImage:
         ioHandler.newImage(context, this);
+        break;
+      case OverflowMenuOption.shareImage:
+      // todo: implement io handeler to share image 
         break;
     }
   }

--- a/lib/ui/pages/workspace_page/components/top_bar/overflow_menu.dart
+++ b/lib/ui/pages/workspace_page/components/top_bar/overflow_menu.dart
@@ -87,7 +87,7 @@ class _OverflowMenuState extends ConsumerState<OverflowMenu> {
         ioHandler.newImage(context, this);
         break;
       case OverflowMenuOption.shareImage:
-      // todo: implement io handeler to share image 
+        ioHandler.shareImage();
         break;
     }
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1032,6 +1032,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.4"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   path_drawing: ^1.0.1
   colorpicker:
     path: packages/colorpicker
+  share_plus: ^10.1.4
 
 dev_dependencies:
   flutter_test:

--- a/test/integration/workspace_overflow_menu_test.dart
+++ b/test/integration/workspace_overflow_menu_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:paintroid/app.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:paintroid/core/tools/tool_data.dart';
@@ -19,6 +20,14 @@ import '../utils/ui_interaction.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
+  const MethodChannel shareChannel =
+  MethodChannel('dev.fluttercommunity.plus/share');
+
+  const MethodChannel pathProviderChannel =
+  MethodChannel('plugins.flutter.io/path_provider');
+
+  bool shareCalled = false;
+
   const String testIDStr = String.fromEnvironment('id', defaultValue: '-1');
   final testID = int.tryParse(testIDStr) ?? -1;
 
@@ -26,6 +35,25 @@ void main() {
   late AppLocalizations localizations;
 
   setUp(() async {
+    shareCalled = false;
+
+    // Mock path_provider
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProviderChannel, (call) async {
+      if (call.method == 'getTemporaryDirectory') {
+        return '/tmp';
+      }
+      return null;
+    });
+
+    // Mock share_plus
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(shareChannel, (call) async {
+      if (call.method == 'shareFiles') {
+        shareCalled = true;
+      }
+      return null;
+    });
     sut = ProviderScope(
       child: App(
         showOnboardingPage: false,
@@ -79,6 +107,9 @@ void main() {
             break;
           case OverflowMenuOption.saveProject:
             label = localizations.saveProject;
+            break;
+          case OverflowMenuOption.shareImage:
+            label = localizations.shareImage;
             break;
         }
         expect(find.text(label), findsOneWidget,
@@ -253,5 +284,18 @@ void main() {
 
       expect(canvasFinder, findsNothing);
     });
+  }
+
+  if (testID == -1 || testID == 12) {
+    testWidgets('[OVERFLOW_MENU]: Share Image uses share_plus',
+            (tester) async {
+          await initializeAppAndLocalizations(tester);
+          await tester.tap(find.byIcon(Icons.more_vert));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text(localizations.shareImage));
+          await tester.pumpAndSettle();
+
+          expect(shareCalled, true);
+        });
   }
 }


### PR DESCRIPTION
Adds a Share Image option to the overflow menu, allowing users to share the current canvas as a PNG image using `share_plus`. Includes integration tests verifying the share action.

## New Features and Enhancements
- Added `Share Image` option to the overflow menu in the workspace.
- Used `share_plus` to trigger the platform share sheet.
- The shared image is generated using the existing canvas export pipeline (`RenderImageForExport`), ensuring the shared image matches the saved image output.

## Refactorings and Bug Fixes
- No refactoring or bug fixes included in this PR.

## Checklist

#### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Add the link to the ticket in Jira in the description of the PR
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines (Wiki)
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Add new information to the [Wiki](https://github.com/Catrobat/Paintroid-Flutter/wiki)

