### PR TITLE
test(serialization): add shape command v2 deserialization coverage

### DIFF
--- a/test/unit/serialization/command/ellipse_shape_serializer_test.dart
+++ b/test/unit/serialization/command/ellipse_shape_serializer_test.dart
@@ -42,4 +42,42 @@ void main() {
       expect(deserializedCommand.type, equals(type));
     });
   });
+
+  group('Version 2', () {
+    test('Test Ellipse deserialization for version 2', () {
+      const type = SerializerType.ELLIPSE_SHAPE_COMMAND;
+      final originalPaint = DummyPaintFactory.createPaint(version: Version.v1);
+      const center = Offset(100, 100);
+      const radius = 50.0;
+      const angle = 0.0;
+      final style = ShapeStyle.outline;
+
+      final command = DummyCommandFactory.createEllipseShapeCommand(
+        originalPaint,
+        radius,
+        radius,
+        center,
+        style,
+        angle,
+      );
+
+      final json = command.toJson();
+      json['version'] = Version.v2;
+      final deserializedCommand = EllipseShapeCommand.fromJson(json);
+
+      expect(
+          DummyPaintFactory.comparePaint(
+            originalPaint,
+            deserializedCommand.paint,
+            version: Version.v1,
+          ),
+          isTrue);
+      expect(deserializedCommand.version, equals(Version.v2));
+      expect(deserializedCommand.center, equals(center));
+      expect(deserializedCommand.radiusX, equals(radius));
+      expect(deserializedCommand.radiusY, equals(radius));
+      expect(deserializedCommand.type, equals(type));
+      expect(deserializedCommand.angle, equals(angle));
+    });
+  });
 }

--- a/test/unit/serialization/command/heart_shape_serializer_test.dart
+++ b/test/unit/serialization/command/heart_shape_serializer_test.dart
@@ -43,4 +43,43 @@ void main() {
       expect(deserializedCommand.style, equals(ShapeStyle.outline));
     });
   });
+
+  group('Version 2', () {
+    test('Test Heart deserialization for version 2', () {
+      const type = SerializerType.HEART_SHAPE_COMMAND;
+      final originalPaint = DummyPaintFactory.createPaint(version: Version.v1);
+      const center = Offset(100, 100);
+      const width = 50.0;
+      const height = 50.0;
+      const angle = 0.0;
+
+      final command = DummyCommandFactory.createHeartShapeCommand(
+        originalPaint,
+        width,
+        height,
+        angle,
+        center,
+        ShapeStyle.outline,
+      );
+
+      final json = command.toJson();
+      json['version'] = Version.v2;
+      final deserializedCommand = HeartShapeCommand.fromJson(json);
+
+      expect(
+          DummyPaintFactory.comparePaint(
+            originalPaint,
+            deserializedCommand.paint,
+            version: Version.v1,
+          ),
+          isTrue);
+      expect(deserializedCommand.version, equals(Version.v2));
+      expect(deserializedCommand.center, equals(center));
+      expect(deserializedCommand.type, equals(type));
+      expect(deserializedCommand.angle, equals(angle));
+      expect(deserializedCommand.width, equals(width));
+      expect(deserializedCommand.height, equals(height));
+      expect(deserializedCommand.style, equals(ShapeStyle.outline));
+    });
+  });
 }

--- a/test/unit/serialization/command/rectangle_shape_serializer_test.dart
+++ b/test/unit/serialization/command/rectangle_shape_serializer_test.dart
@@ -44,4 +44,44 @@ void main() {
       expect(deserializedCommand.type, equals(type));
     });
   });
+
+  group('Version 2', () {
+    test('Test SquareShapeCommand deserialization for version 2', () {
+      const type = SerializerType.SQUARE_SHAPE_COMMAND;
+
+      final originalPaint = DummyPaintFactory.createPaint(version: Version.v1);
+      const originalTopLeft = Offset(0, 0);
+      const originalTopRight = Offset(1, 0);
+      const originalBottomLeft = Offset(0, 1);
+      const originalBottomRight = Offset(1, 1);
+
+      final command = DummyCommandFactory.createSquareShapeCommand(
+        originalPaint,
+        originalTopLeft,
+        originalTopRight,
+        originalBottomLeft,
+        originalBottomRight,
+        ShapeStyle.outline,
+        version: Version.v1,
+      );
+
+      final json = command.toJson();
+      json['version'] = Version.v2;
+      final deserializedCommand = SquareShapeCommand.fromJson(json);
+
+      expect(
+          DummyPaintFactory.comparePaint(
+            originalPaint,
+            deserializedCommand.paint,
+            version: Version.v1,
+          ),
+          isTrue);
+      expect(deserializedCommand.version, equals(Version.v2));
+      expect(deserializedCommand.topLeft, equals(originalTopLeft));
+      expect(deserializedCommand.topRight, equals(originalTopRight));
+      expect(deserializedCommand.bottomLeft, equals(originalBottomLeft));
+      expect(deserializedCommand.bottomRight, equals(originalBottomRight));
+      expect(deserializedCommand.type, equals(type));
+    });
+  });
 }

--- a/test/unit/serialization/command/star_shape_serializer_test.dart
+++ b/test/unit/serialization/command/star_shape_serializer_test.dart
@@ -45,4 +45,46 @@ void main() {
       expect(deserializedCommand.angle, equals(angle));
     });
   });
+
+  group('Version 2', () {
+    test('Test Star deserialization for version 2', () {
+      const type = SerializerType.STAR_SHAPE_COMMAND;
+      final originalPaint = DummyPaintFactory.createPaint(version: Version.v1);
+      const center = Offset(100, 100);
+      const radius = 50.0;
+      const numberOfPoints = 5;
+      const angle = 0.0;
+
+      final style = ShapeStyle.outline;
+
+      final command = DummyCommandFactory.createStarShapeCommand(
+        originalPaint,
+        numberOfPoints,
+        angle,
+        center,
+        style,
+        radius,
+        radius,
+      );
+
+      final json = command.toJson();
+      json['version'] = Version.v2;
+      final deserializedCommand = StarShapeCommand.fromJson(json);
+
+      expect(
+          DummyPaintFactory.comparePaint(
+            originalPaint,
+            deserializedCommand.paint,
+            version: Version.v1,
+          ),
+          isTrue);
+      expect(deserializedCommand.version, equals(Version.v2));
+      expect(deserializedCommand.center, equals(center));
+      expect(deserializedCommand.radiusX, equals(radius));
+      expect(deserializedCommand.radiusY, equals(radius));
+      expect(deserializedCommand.type, equals(type));
+      expect(deserializedCommand.numberOfPoints, equals(numberOfPoints));
+      expect(deserializedCommand.angle, equals(angle));
+    });
+  });
 }


### PR DESCRIPTION
# PR Description

Jira ticket: NA
Jira link: NA

## Summary

This PR adds backward-compatibility unit test coverage for shape command deserialization when version is set to v2.

Scope:
- Test-only changes
- No production serializer behavior changes
- No UI or feature logic changes

## New Features and Enhancements
- Added v2 deserialization coverage for:
  - Square shape command serializer tests
  - Star shape command serializer tests
  - Heart shape command serializer tests
  - Ellipse shape command serializer tests

## Refactorings and Bug Fixes
- None in production code.
- This PR focuses on regression safety and compatibility confidence through tests.

## Validation
- Ran targeted tests for all updated shape serializer test files
- Ran serialization command test suite locally
- All passed locally

## Checklist

#### Your checklist for this pull request
Please review the contributing guidelines and wiki pages of this repository.

- [ ] Include the name of the Jira ticket in the PR title
- [ ] Add the link to the ticket in Jira in the description of the PR
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (develop)
- [x] Confirm that the changes follow the project coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing tests pass locally
- [x] Check that the commit message style matches the project guideline
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Add new information to the Wiki (if required)