### PR TITLE
[PAINTROID-727] Transparent NavBar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,6 +25,14 @@ void main() async {
   );
 
   WidgetsFlutterBinding.ensureInitialized();
+
+  SystemChrome.setSystemUIOverlayStyle(
+    const SystemUiOverlayStyle(
+      systemNavigationBarColor: Colors.transparent,
+    ),
+  );
+  SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+
   const platform = MethodChannel('org.catrobat.paintroid/file_handler');
   String? initialFileUri;
 


### PR DESCRIPTION
This change only affects android 14 or lower, with android 15 this behavior is enforced
[Behavior changes](https://developer.android.com/about/versions/15/behavior-changes-15#edge-to-edge)
[Jira Link](https://catrobat.atlassian.net/browse/PAINTROID-727)

## Refactorings and Bug Fixes
- Navigation bar transparent for android 14 and lower

## Checklist

#### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Add the link to the ticket in Jira in the description of the PR
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines (Wiki)
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Add new information to the [Wiki](https://github.com/Catrobat/Paintroid-Flutter/wiki)

