### PR TITLE
Fix iOS crash on startup from missing file_handler plugin

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,6 +38,8 @@ void main() async {
 
   try {
     initialFileUri = await platform.invokeMethod('getInitialFile');
+  } on MissingPluginException {
+    // file_handler channel is Android-only; no-op on iOS.
   } on PlatformException catch (e) {
     log("Failed to get initial file: '${e.message}'.");
   }


### PR DESCRIPTION
## Summary
- iOS crashes on startup with `MissingPluginException` from the `org.catrobat.paintroid/file_handler` MethodChannel (introduced in #146). The existing `try` only catches `PlatformException`, which is a distinct class — `main()` crashes before `runApp()`, leaving a white screen.
- Adds an explicit `on MissingPluginException` catch that no-ops. The file_handler channel is implemented on Android only; iOS doesn't support the open-from-Files flow yet.

## Reproduction (before this fix)
1. `flutter run -d <ios-simulator>` on current develop
2. App boots to white screen
3. Console shows: `Unhandled Exception: MissingPluginException(No implementation found for method getInitialFile on channel org.catrobat.paintroid/file_handler)` originating in [lib/main.dart:40](https://github.com/Catrobat/Paintroid-Flutter/blob/develop/lib/main.dart#L40)

## Test plan
- [ ] `flutter run` on iOS simulator → app reaches Pocket Paint home screen
- [ ] `flutter run` on Android → file-open-from-Files flow still works (Android handler unaffected)
- [ ] Existing test suite still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)