### PR TITLE
PAINTROID-810 Update AGP and Kotlin versions

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.5.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.24" apply false
+    id "com.android.application" version "8.7.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"


### PR DESCRIPTION
*This PR resolves the Android build dependency warnings by updating the Android Gradle Plugin and Kotlin to their modern, supported versions (AGP 8.7.0 and Kotlin 2.1.0).*

[PAINTROID-810](https://catrobat.atlassian.net/browse/PAINTROID-810)

## New Features and Enhancements
- None

## Refactorings and Bug Fixes
- Upgraded Android Gradle Plugin (AGP) from `8.5.0` to `8.7.0`
- Upgraded Kotlin version from `1.9.24` to `2.1.0`
- Resolved Gradle compatibility warnings introduced by recent Flutter upgrade

## Checklist

#### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Add the link to the ticket in Jira in the description of the PR
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines (Wiki)
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior *(N/A - build config update)*
- [x] Confirm that new and existing tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Add new information to the [Wiki](https://github.com/Catrobat/Paintroid-Flutter/wiki) *(N/A)*


[PAINTROID-810]: https://catrobat.atlassian.net/browse/PAINTROID-810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ