### PR TITLE
PAINTROID-761: Implement foundational Kryo binary reader in Dart

### DIFF
--- a/lib/core/backward_compatibility/kryo_reader.dart
+++ b/lib/core/backward_compatibility/kryo_reader.dart
@@ -1,0 +1,181 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+class KryoReader {
+  final Uint8List _bytes;
+  int _position = 0;
+
+  KryoReader(this._bytes);
+
+  int get position => _position;
+
+  set position(int pos) {
+    if (pos >= 0 && pos <= _bytes.length) {
+      _position = pos;
+    }
+  }
+
+  bool get hasRemaining => _position < _bytes.length;
+
+  int get remaining => _bytes.length - _position;
+
+  int readByte() {
+    if (_position >= _bytes.length) {
+      throw RangeError(
+        'Index out of bounds: Attempted to read past the end of the byte stream.',
+      );
+    }
+    return _bytes[_position++];
+  }
+
+  Uint8List readBytes(int length) {
+    if (length < 0) {
+      throw ArgumentError('Length cannot be negative.');
+    }
+    if (_position + length > _bytes.length) {
+      throw RangeError(
+        'Index out of bounds: Attempted to read $length bytes, but only $remaining are remaining.',
+      );
+    }
+    final result = Uint8List.sublistView(_bytes, _position, _position + length);
+    _position += length;
+    return result;
+  }
+
+  int readInt32({Endian endian = Endian.little}) {
+    final bytes = readBytes(4);
+    final byteData = ByteData.sublistView(bytes);
+    return byteData.getInt32(0, endian);
+  }
+
+  int readInt64({Endian endian = Endian.little}) {
+    final bytes = readBytes(8);
+    final byteData = ByteData.sublistView(bytes);
+    return byteData.getInt64(0, endian);
+  }
+
+  double readFloat({Endian endian = Endian.little}) {
+    final bytes = readBytes(4);
+    final byteData = ByteData.sublistView(bytes);
+    return byteData.getFloat32(0, endian);
+  }
+
+  double readDouble({Endian endian = Endian.little}) {
+    final bytes = readBytes(8);
+    final byteData = ByteData.sublistView(bytes);
+    return byteData.getFloat64(0, endian);
+  }
+
+  bool readBoolean() {
+    return readByte() != 0;
+  }
+
+  int readChar({Endian endian = Endian.little}) {
+    final bytes = readBytes(2);
+    final byteData = ByteData.sublistView(bytes);
+    return byteData.getUint16(0, endian);
+  }
+
+  int readVarInt(bool optimizePositive) {
+    if (!hasRemaining) {
+      throw RangeError(
+        'Index out of bounds: No bytes remaining to read varint.',
+      );
+    }
+    int b = readByte();
+    int result = b & 0x7F;
+    if ((b & 0x80) != 0) {
+      b = readByte();
+      result |= (b & 0x7F) << 7;
+      if ((b & 0x80) != 0) {
+        b = readByte();
+        result |= (b & 0x7F) << 14;
+        if ((b & 0x80) != 0) {
+          b = readByte();
+          result |= (b & 0x7F) << 21;
+          if ((b & 0x80) != 0) {
+            b = readByte();
+            result |= (b & 0x7F) << 28;
+          }
+        }
+      }
+    }
+    if (optimizePositive) {
+      return result;
+    } else {
+      // Decode ZigZag encoding for signed integers
+      return (result >> 1) ^ -(result & 1);
+    }
+  }
+
+  int readVarLong(bool optimizePositive) {
+    if (!hasRemaining) {
+      throw RangeError(
+        'Index out of bounds: No bytes remaining to read varlong.',
+      );
+    }
+    int b = readByte();
+    int result = b & 0x7F;
+    if ((b & 0x80) != 0) {
+      b = readByte();
+      result |= (b & 0x7F) << 7;
+      if ((b & 0x80) != 0) {
+        b = readByte();
+        result |= (b & 0x7F) << 14;
+        if ((b & 0x80) != 0) {
+          b = readByte();
+          result |= (b & 0x7F) << 21;
+          if ((b & 0x80) != 0) {
+            b = readByte();
+            result |= (b & 0x7F) << 28;
+            if ((b & 0x80) != 0) {
+              b = readByte();
+              result |= (b & 0x7F) << 35;
+              if ((b & 0x80) != 0) {
+                b = readByte();
+                result |= (b & 0x7F) << 42;
+                if ((b & 0x80) != 0) {
+                  b = readByte();
+                  result |= (b & 0x7F) << 49;
+                  if ((b & 0x80) != 0) {
+                    b = readByte();
+                    result |= b << 56;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    if (optimizePositive) {
+      return result;
+    } else {
+      // Decode ZigZag encoding
+      return (result >> 1) ^ -(result & 1);
+    }
+  }
+
+  String? readString() {
+    final int length = readVarInt(true);
+    if (length == 0) {
+      return null;
+    }
+    if (length == 1) {
+      return '';
+    }
+
+    final int charCount = length - 1;
+    final bytes = readBytes(charCount);
+
+    // Handle Kryo ASCII optimization (MSB flag on the last byte)
+    if (bytes.isNotEmpty && (bytes.last & 0x80) != 0) {
+      final List<int> decodedBytes = List<int>.from(bytes);
+      decodedBytes[decodedBytes.length - 1] &= 0x7F;
+      return ascii.decode(decodedBytes);
+    }
+
+    return utf8.decode(bytes);
+  }
+}
+

--- a/test/unit/serialization/kryo_reader_test.dart
+++ b/test/unit/serialization/kryo_reader_test.dart
@@ -1,0 +1,115 @@
+import 'dart:typed_data';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:paintroid/core/backward_compatibility/kryo_reader.dart';
+
+void main() {
+  group('KryoReader Primitives', () {
+    test('readByte and readBytes should navigate through stream correctly', () {
+      final bytes = Uint8List.fromList([0x10, 0x20, 0x30, 0x40]);
+      final reader = KryoReader(bytes);
+
+      expect(reader.position, equals(0));
+      expect(reader.remaining, equals(4));
+      expect(reader.hasRemaining, isTrue);
+
+      expect(reader.readByte(), equals(0x10));
+      expect(reader.position, equals(1));
+
+      final sublist = reader.readBytes(2);
+      expect(sublist, equals([0x20, 0x30]));
+      expect(reader.position, equals(3));
+      expect(reader.remaining, equals(1));
+
+      expect(reader.readByte(), equals(0x40));
+      expect(reader.hasRemaining, isFalse);
+
+      expect(() => reader.readByte(), throwsRangeError);
+    });
+
+    test('readBoolean should return correct values', () {
+      final bytes = Uint8List.fromList([0x00, 0x01, 0xFF]);
+      final reader = KryoReader(bytes);
+
+      expect(reader.readBoolean(), isFalse);
+      expect(reader.readBoolean(), isTrue);
+      expect(reader.readBoolean(), isTrue);
+    });
+
+    test('readInt32 and readInt64 should read fixed size values', () {
+      // Little-endian fixed representation tests
+      final bytes = Uint8List.fromList([
+        0x2A, 0x00, 0x00, 0x00, // 42 in 32-bit
+        0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 100 in 64-bit
+      ]);
+      final reader = KryoReader(bytes);
+
+      expect(reader.readInt32(), equals(42));
+      expect(reader.readInt64(), equals(100));
+    });
+
+    test('readFloat and readDouble should parse IEEE 754 representations', () {
+      // Little-endian IEEE 754 representations: 2.5 (float) and 3.14 (double)
+      final bytes = Uint8List.fromList([
+        0x00, 0x00, 0x20, 0x40,
+        0x1F, 0x85, 0xEB, 0x51, 0xB8, 0x1E, 0x09, 0x40,
+      ]);
+      final reader = KryoReader(bytes);
+
+      expect(reader.readFloat(), equals(2.5));
+      expect(reader.readDouble(), closeTo(3.14, 0.0001));
+    });
+  });
+
+  group('KryoReader VarInts and VarLongs', () {
+    test('readVarInt (optimizePositive = true)', () {
+      // Varint boundary value tests
+      final bytes = Uint8List.fromList([
+        0x00, // 0
+        0x7F, // 127
+        0x80, 0x01, // 128
+        0xFF, 0x7F, // 16383
+        0x80, 0x80, 0x01, // 16384
+      ]);
+      final reader = KryoReader(bytes);
+
+      expect(reader.readVarInt(true), equals(0));
+      expect(reader.readVarInt(true), equals(127));
+      expect(reader.readVarInt(true), equals(128));
+      expect(reader.readVarInt(true), equals(16383));
+      expect(reader.readVarInt(true), equals(16384));
+    });
+
+    test('readVarInt (optimizePositive = false)', () {
+      // ZigZag-encoded varint tests
+      final bytes = Uint8List.fromList([0x01, 0x02, 0x03, 0x04]);
+      final reader = KryoReader(bytes);
+
+      expect(reader.readVarInt(false), equals(-1));
+      expect(reader.readVarInt(false), equals(1));
+      expect(reader.readVarInt(false), equals(-2));
+      expect(reader.readVarInt(false), equals(2));
+    });
+  });
+
+  group('KryoReader String Parsing', () {
+    test(
+      'readString should handle null, empty, standard, and optimized ASCII strings',
+      () {
+        // String format tests including ASCII optimization MSB mask
+        final bytes = Uint8List.fromList([
+          0x00, // null
+          0x01, // empty string
+          0x04, 0x43, 0x61, 0xF4, // "Cat" (MSB set on 't': 0xF4)
+          0x05, 0x44, 0x61, 0x72, 0x74, // "Dart" (standard)
+        ]);
+        final reader = KryoReader(bytes);
+
+        expect(reader.readString(), isNull);
+        expect(reader.readString(), equals(''));
+        expect(reader.readString(), equals('Cat'));
+        expect(reader.readString(), equals('Dart'));
+      },
+    );
+  });
+}
+


### PR DESCRIPTION
*This Pull Request is the first step of our 4-stage plan to add backward compatibility for legacy `.catrobat` files. It introduces the low-level binary reader in Dart to decode raw Kryo streams.*

[PAINTROID-761](https://catrobat.atlassian.net/browse/PAINTROID-761) 

*Note: The comments in the code have been kept to make review of the binary format easier, and they will be removed once the PR has been reviewed.*

## New Features and Enhancements
- **Implemented Foundational Kryo Binary Reader (`KryoReader`)**: Created a high-performance binary reader under `lib/core/backward_compatibility/kryo_reader.dart` to decode primitive data types (integers, floats, doubles, booleans, characters).
- **Varint and Varlong Decoding**: Added support for variable-length integers and longs used in Kryo serialization, including ZigZag decoding for signed compression.
- **Kryo String Protocol**: Implemented full Kryo string specifications (handling null strings, empty strings, and UTF-8/ASCII bytes) including support for Kryo's custom ASCII-optimization flag.
- **Robust Unit Testing**: Added comprehensive unit tests under `test/unit/serialization/kryo_reader_test.dart` to verify navigation, fixed primitives, varints, and optimized strings. All tests are passing locally.
- **Isolated Implementation**: Kept all new code separated under `lib/core/backward_compatibility/`, ensuring zero impact on the existing codebase during review.

---

### Backward Compatibility Roadmap
To make this feature easy to review and track, the work is organized into four sequential stages:
1. **Stage 1 (This PR - Foundational Binary Reader)**: The low-level `KryoReader` to parse bytes into basic Dart datatypes (ints, strings, doubles).
2. **Stage 2 (Registry & Model Parser)**: Setting up the class registry matching the native app's sequential registration IDs to reconstruct raw objects (like `CommandManagerModel` and `ColorHistory`).
3. **Stage 3 (Command Transformation)**: Converting those legacy Android commands (such as historical lines, shapes, and layer state changes) into their equivalent Flutter drawing commands.
4. **Stage 4 (UI Performance & Fallbacks)**: Running the decoding logic on background isolates to keep the UI smooth during large file loads, and adding fallback renderers for legacy tools not yet supported by Flutter.

## Refactorings and Bug Fixes
- None (New feature foundation).

## Checklist

#### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Add the link to the ticket in Jira in the description of the PR
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines (Wiki)
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Add new information to the [Wiki](https://github.com/Catrobat/Paintroid-Flutter/wiki)


[PAINTROID-761]: https://catrobat.atlassian.net/browse/PAINTROID-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ