### PR TITLE
PAINTROID-761-2: Reconstruct Legacy Command Models from Binary Stream

### DIFF
--- a/lib/core/backward_compatibility/kryo_class_registry.dart
+++ b/lib/core/backward_compatibility/kryo_class_registry.dart
@@ -54,8 +54,6 @@ class KryoClassRegistry {
     55: 'LayerOpacityCommand',
   };
 
-  /// Decodes a class registration ID from the stream and resolves its class name.
-  /// Kryo writes class references as: registrationID + 2 (0 represents null).
   static String? readClassName(KryoReader reader) {
     final int encodedId = reader.readVarInt(true);
     if (encodedId == 0) {
@@ -71,7 +69,6 @@ class KryoClassRegistry {
     return className;
   }
 
-  /// Deserializes registered objects from the Kryo binary stream.
   static dynamic readClassAndObject(KryoReader reader) {
     final String? className = readClassName(reader);
     if (className == null) {
@@ -106,7 +103,6 @@ class KryoClassRegistry {
       case 'SerializablePathCube':
         return LegacySerializablePathCube.deserialize(reader);
       default:
-        // Returns the class name to be handled dynamically by specific command parsers
         return className;
     }
   }

--- a/lib/core/backward_compatibility/kryo_class_registry.dart
+++ b/lib/core/backward_compatibility/kryo_class_registry.dart
@@ -1,0 +1,113 @@
+import 'package:paintroid/core/backward_compatibility/kryo_reader.dart';
+import 'package:paintroid/core/backward_compatibility/legacy_deserializers.dart';
+
+class KryoClassRegistry {
+  static const int baseRegistrationId = 9;
+
+  static const Map<int, String> classMap = {
+    9: 'Command',
+    10: 'CompositeCommand',
+    11: 'FloatArray',
+    12: 'PointF',
+    13: 'Point',
+    14: 'CommandManagerModel',
+    15: 'SetDimensionCommand',
+    16: 'SprayCommand',
+    17: 'Paint',
+    18: 'AddEmptyLayerCommand',
+    19: 'SelectLayerCommand',
+    20: 'LoadCommand',
+    21: 'TextToolCommand',
+    22: 'StringArray',
+    23: 'FillCommand',
+    24: 'FlipCommand',
+    25: 'CropCommand',
+    26: 'CutCommand',
+    27: 'ResizeCommand',
+    28: 'RotateCommand',
+    29: 'ResetCommand',
+    30: 'ReorderLayersCommand',
+    31: 'RemoveLayerCommand',
+    32: 'MergeLayersCommand',
+    33: 'PathCommand',
+    34: 'SerializablePath',
+    35: 'SerializablePathMove',
+    36: 'SerializablePathLine',
+    37: 'SerializablePathQuad',
+    38: 'SerializablePathRewind',
+    39: 'LoadLayerListCommand',
+    40: 'GeometricFillCommand',
+    41: 'HeartDrawable',
+    42: 'OvalDrawable',
+    43: 'RectangleDrawable',
+    44: 'StarDrawable',
+    45: 'ShapeDrawable',
+    46: 'RectF',
+    47: 'ClipboardCommand',
+    48: 'SerializableTypeface',
+    49: 'PointCommand',
+    50: 'SerializablePathCube',
+    51: 'Bitmap',
+    52: 'SmudgePathCommand',
+    53: 'ColorHistory',
+    54: 'ClippingCommand',
+    55: 'LayerOpacityCommand',
+  };
+
+  /// Decodes a class registration ID from the stream and resolves its class name.
+  /// Kryo writes class references as: registrationID + 2 (0 represents null).
+  static String? readClassName(KryoReader reader) {
+    final int encodedId = reader.readVarInt(true);
+    if (encodedId == 0) {
+      return null;
+    }
+    final int classId = encodedId - 2;
+    final className = classMap[classId];
+    if (className == null) {
+      throw FormatException(
+        'Unknown or unregistered legacy class ID: $classId',
+      );
+    }
+    return className;
+  }
+
+  /// Deserializes registered objects from the Kryo binary stream.
+  static dynamic readClassAndObject(KryoReader reader) {
+    final String? className = readClassName(reader);
+    if (className == null) {
+      return null;
+    }
+
+    switch (className) {
+      case 'Point':
+        return LegacyPoint.deserialize(reader);
+      case 'PointF':
+        return LegacyPointF.deserialize(reader);
+      case 'RectF':
+        return LegacyRectF.deserialize(reader);
+      case 'Paint':
+        return LegacyPaint.deserialize(reader);
+      case 'ColorHistory':
+        return LegacyColorHistory.deserialize(reader);
+      case 'FloatArray':
+        return LegacyFloatArray.deserialize(reader).values;
+      case 'StringArray':
+        return LegacyStringArray.deserialize(reader).values;
+      case 'SerializablePath':
+        return LegacySerializablePath.deserialize(reader);
+      case 'SerializablePathMove':
+        return LegacySerializablePathMove.deserialize(reader);
+      case 'SerializablePathLine':
+        return LegacySerializablePathLine.deserialize(reader);
+      case 'SerializablePathQuad':
+        return LegacySerializablePathQuad.deserialize(reader);
+      case 'SerializablePathRewind':
+        return LegacySerializablePathRewind.deserialize(reader);
+      case 'SerializablePathCube':
+        return LegacySerializablePathCube.deserialize(reader);
+      default:
+        // Returns the class name to be handled dynamically by specific command parsers
+        return className;
+    }
+  }
+}

--- a/lib/core/backward_compatibility/kryo_reader.dart
+++ b/lib/core/backward_compatibility/kryo_reader.dart
@@ -103,7 +103,6 @@ class KryoReader {
     if (optimizePositive) {
       return result;
     } else {
-      // Decode ZigZag encoding for signed integers
       return (result >> 1) ^ -(result & 1);
     }
   }
@@ -151,7 +150,6 @@ class KryoReader {
     if (optimizePositive) {
       return result;
     } else {
-      // Decode ZigZag encoding
       return (result >> 1) ^ -(result & 1);
     }
   }
@@ -168,7 +166,6 @@ class KryoReader {
     final int charCount = length - 1;
     final bytes = readBytes(charCount);
 
-    // Handle Kryo ASCII optimization (MSB flag on the last byte)
     if (bytes.isNotEmpty && (bytes.last & 0x80) != 0) {
       final List<int> decodedBytes = List<int>.from(bytes);
       decodedBytes[decodedBytes.length - 1] &= 0x7F;

--- a/lib/core/backward_compatibility/legacy_deserializers.dart
+++ b/lib/core/backward_compatibility/legacy_deserializers.dart
@@ -1,0 +1,299 @@
+import 'package:paintroid/core/backward_compatibility/kryo_class_registry.dart';
+import 'package:paintroid/core/backward_compatibility/kryo_reader.dart';
+
+class LegacyPoint {
+  final int x;
+  final int y;
+
+  LegacyPoint(this.x, this.y);
+
+  factory LegacyPoint.deserialize(KryoReader reader) {
+    final x = reader.readInt32();
+    final y = reader.readInt32();
+    return LegacyPoint(x, y);
+  }
+
+  Map<String, dynamic> toJson() => {'x': x, 'y': y};
+}
+
+class LegacyPointF {
+  final double x;
+  final double y;
+
+  LegacyPointF(this.x, this.y);
+
+  factory LegacyPointF.deserialize(KryoReader reader) {
+    final x = reader.readFloat();
+    final y = reader.readFloat();
+    return LegacyPointF(x, y);
+  }
+
+  Map<String, dynamic> toJson() => {'x': x, 'y': y};
+}
+
+class LegacyRectF {
+  final double left;
+  final double top;
+  final double right;
+  final double bottom;
+
+  LegacyRectF(this.left, this.top, this.right, this.bottom);
+
+  factory LegacyRectF.deserialize(KryoReader reader) {
+    final left = reader.readFloat();
+    final top = reader.readFloat();
+    final right = reader.readFloat();
+    final bottom = reader.readFloat();
+    return LegacyRectF(left, top, right, bottom);
+  }
+
+  Map<String, dynamic> toJson() => {
+    'left': left,
+    'top': top,
+    'right': right,
+    'bottom': bottom,
+  };
+}
+
+class LegacyPaint {
+  final int color;
+  final double strokeWidth;
+  final int strokeCap;
+  final bool isAntiAlias;
+  final int style;
+  final int strokeJoin;
+  final bool hadFilter;
+  final int alpha;
+
+  LegacyPaint({
+    required this.color,
+    required this.strokeWidth,
+    required this.strokeCap,
+    required this.isAntiAlias,
+    required this.style,
+    required this.strokeJoin,
+    required this.hadFilter,
+    required this.alpha,
+  });
+
+  factory LegacyPaint.deserialize(KryoReader reader) {
+    final color = reader.readInt32();
+    final strokeWidth = reader.readFloat();
+    final strokeCap = reader.readInt32();
+    final isAntiAlias = reader.readBoolean();
+    final style = reader.readInt32();
+    final strokeJoin = reader.readInt32();
+    final hadFilter = reader.readBoolean();
+    final alpha = reader.readInt32();
+
+    return LegacyPaint(
+      color: color,
+      strokeWidth: strokeWidth,
+      strokeCap: strokeCap,
+      isAntiAlias: isAntiAlias,
+      style: style,
+      strokeJoin: strokeJoin,
+      hadFilter: hadFilter,
+      alpha: alpha,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'color': color,
+    'strokeWidth': strokeWidth,
+    'strokeCap': strokeCap,
+    'isAntiAlias': isAntiAlias,
+    'style': style,
+    'strokeJoin': strokeJoin,
+    'hadFilter': hadFilter,
+    'alpha': alpha,
+  };
+}
+
+class LegacyColorHistory {
+  final List<int> colors;
+
+  LegacyColorHistory(this.colors);
+
+  factory LegacyColorHistory.deserialize(KryoReader reader) {
+    final size = reader.readInt32();
+    final List<int> colors = [];
+    for (int i = 0; i < size; i++) {
+      colors.add(reader.readInt32());
+    }
+    return LegacyColorHistory(colors);
+  }
+
+  Map<String, dynamic> toJson() => {'colors': colors};
+}
+
+class LegacyFloatArray {
+  final List<double> values;
+
+  LegacyFloatArray(this.values);
+
+  factory LegacyFloatArray.deserialize(KryoReader reader) {
+    final size = reader.readInt32();
+    final List<double> values = [];
+    for (int i = 0; i < size; i++) {
+      values.add(reader.readFloat());
+    }
+    return LegacyFloatArray(values);
+  }
+}
+
+class LegacyStringArray {
+  final List<String> values;
+
+  LegacyStringArray(this.values);
+
+  factory LegacyStringArray.deserialize(KryoReader reader) {
+    final size = reader.readInt32();
+    final List<String> values = [];
+    for (int i = 0; i < size; i++) {
+      final str = reader.readString();
+      if (str != null) {
+        values.add(str);
+      }
+    }
+    return LegacyStringArray(values);
+  }
+}
+
+abstract class LegacySerializableAction {
+  Map<String, dynamic> toJson();
+}
+
+class LegacySerializablePathMove implements LegacySerializableAction {
+  final double x;
+  final double y;
+
+  LegacySerializablePathMove(this.x, this.y);
+
+  factory LegacySerializablePathMove.deserialize(KryoReader reader) {
+    final x = reader.readFloat();
+    final y = reader.readFloat();
+    return LegacySerializablePathMove(x, y);
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {'type': 'Move', 'x': x, 'y': y};
+}
+
+class LegacySerializablePathLine implements LegacySerializableAction {
+  final double x;
+  final double y;
+
+  LegacySerializablePathLine(this.x, this.y);
+
+  factory LegacySerializablePathLine.deserialize(KryoReader reader) {
+    final x = reader.readFloat();
+    final y = reader.readFloat();
+    return LegacySerializablePathLine(x, y);
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {'type': 'Line', 'x': x, 'y': y};
+}
+
+class LegacySerializablePathQuad implements LegacySerializableAction {
+  final double x1;
+  final double y1;
+  final double x2;
+  final double y2;
+
+  LegacySerializablePathQuad(this.x1, this.y1, this.x2, this.y2);
+
+  factory LegacySerializablePathQuad.deserialize(KryoReader reader) {
+    final x1 = reader.readFloat();
+    final y1 = reader.readFloat();
+    final x2 = reader.readFloat();
+    final y2 = reader.readFloat();
+    return LegacySerializablePathQuad(x1, y1, x2, y2);
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'Quad',
+    'x1': x1,
+    'y1': y1,
+    'x2': x2,
+    'y2': y2,
+  };
+}
+
+class LegacySerializablePathCube implements LegacySerializableAction {
+  final double x1;
+  final double y1;
+  final double x2;
+  final double y2;
+  final double x3;
+  final double y3;
+
+  LegacySerializablePathCube(
+    this.x1,
+    this.y1,
+    this.x2,
+    this.y2,
+    this.x3,
+    this.y3,
+  );
+
+  factory LegacySerializablePathCube.deserialize(KryoReader reader) {
+    final x1 = reader.readFloat();
+    final y1 = reader.readFloat();
+    final x2 = reader.readFloat();
+    final y2 = reader.readFloat();
+    final x3 = reader.readFloat();
+    final y3 = reader.readFloat();
+    return LegacySerializablePathCube(x1, y1, x2, y2, x3, y3);
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'Cube',
+    'x1': x1,
+    'y1': y1,
+    'x2': x2,
+    'y2': y2,
+    'x3': x3,
+    'y3': y3,
+  };
+}
+
+class LegacySerializablePathRewind implements LegacySerializableAction {
+  LegacySerializablePathRewind();
+
+  factory LegacySerializablePathRewind.deserialize(KryoReader reader) {
+    return LegacySerializablePathRewind();
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {'type': 'Rewind'};
+}
+
+class LegacySerializablePath {
+  final List<LegacySerializableAction> actions;
+
+  LegacySerializablePath(this.actions);
+
+  factory LegacySerializablePath.deserialize(KryoReader reader) {
+    final size = reader.readInt32();
+    final List<LegacySerializableAction> actions = [];
+    for (int i = 0; i < size; i++) {
+      final action = KryoClassRegistry.readClassAndObject(reader);
+      if (action is LegacySerializableAction) {
+        actions.add(action);
+      } else {
+        throw FormatException(
+          'Unexpected path action type in path list: $action',
+        );
+      }
+    }
+    return LegacySerializablePath(actions);
+  }
+
+  Map<String, dynamic> toJson() => {
+    'actions': actions.map((a) => a.toJson()).toList(),
+  };
+}

--- a/lib/core/backward_compatibility/legacy_model_parser.dart
+++ b/lib/core/backward_compatibility/legacy_model_parser.dart
@@ -10,7 +10,6 @@ class LegacyCommandManagerModel {
     required this.commands,
   });
 
-  /// Deserializes the CommandManagerModel structure from the Kryo binary reader.
   factory LegacyCommandManagerModel.deserialize(KryoReader reader) {
     final String? initClassName = KryoClassRegistry.readClassName(reader);
     if (initClassName == null) {

--- a/lib/core/backward_compatibility/legacy_model_parser.dart
+++ b/lib/core/backward_compatibility/legacy_model_parser.dart
@@ -1,0 +1,127 @@
+import 'package:paintroid/core/backward_compatibility/kryo_class_registry.dart';
+import 'package:paintroid/core/backward_compatibility/kryo_reader.dart';
+
+class LegacyCommandManagerModel {
+  final dynamic initialCommand;
+  final List<dynamic> commands;
+
+  LegacyCommandManagerModel({
+    required this.initialCommand,
+    required this.commands,
+  });
+
+  /// Deserializes the CommandManagerModel structure from the Kryo binary reader.
+  factory LegacyCommandManagerModel.deserialize(KryoReader reader) {
+    final String? initClassName = KryoClassRegistry.readClassName(reader);
+    if (initClassName == null) {
+      throw FormatException(
+        'Legacy CommandManagerModel initialCommand cannot be null.',
+      );
+    }
+    final dynamic initialCommand = _deserializeCommand(initClassName, reader);
+
+    final int size = reader.readInt32();
+
+    final List<dynamic> commands = [];
+    for (int i = 0; i < size; i++) {
+      final String? className = KryoClassRegistry.readClassName(reader);
+      if (className != null) {
+        commands.add(_deserializeCommand(className, reader));
+      }
+    }
+
+    return LegacyCommandManagerModel(
+      initialCommand: initialCommand,
+      commands: commands,
+    );
+  }
+
+  static dynamic _deserializeCommand(String className, KryoReader reader) {
+    switch (className) {
+      case 'SetDimensionCommand':
+        final int width = reader.readInt32();
+        final int height = reader.readInt32();
+        return {
+          'type': 'SetDimensionCommand',
+          'width': width,
+          'height': height,
+        };
+      case 'PathCommand':
+        final paint = KryoClassRegistry.readClassAndObject(reader);
+        final path = KryoClassRegistry.readClassAndObject(reader);
+        return {'type': 'PathCommand', 'paint': paint, 'path': path};
+      case 'AddEmptyLayerCommand':
+        return {'type': 'AddEmptyLayerCommand'};
+      case 'SelectLayerCommand':
+        final int layerIndex = reader.readInt32();
+        return {'type': 'SelectLayerCommand', 'layerIndex': layerIndex};
+      case 'RemoveLayerCommand':
+        final int layerIndex = reader.readInt32();
+        return {'type': 'RemoveLayerCommand', 'layerIndex': layerIndex};
+      case 'MergeLayersCommand':
+        final int bottomLayerIndex = reader.readInt32();
+        final int topLayerIndex = reader.readInt32();
+        return {
+          'type': 'MergeLayersCommand',
+          'bottomLayerIndex': bottomLayerIndex,
+          'topLayerIndex': topLayerIndex,
+        };
+      case 'ReorderLayersCommand':
+        final int fromIndex = reader.readInt32();
+        final int toIndex = reader.readInt32();
+        return {
+          'type': 'ReorderLayersCommand',
+          'fromIndex': fromIndex,
+          'toIndex': toIndex,
+        };
+      case 'LayerOpacityCommand':
+        final int layerIndex = reader.readInt32();
+        final double opacity = reader.readFloat();
+        return {
+          'type': 'LayerOpacityCommand',
+          'layerIndex': layerIndex,
+          'opacity': opacity,
+        };
+      case 'FlipCommand':
+        final int flipDirection = reader.readInt32();
+        return {'type': 'FlipCommand', 'flipDirection': flipDirection};
+      case 'RotateCommand':
+        final int rotateDirection = reader.readInt32();
+        return {'type': 'RotateCommand', 'rotateDirection': rotateDirection};
+      case 'CropCommand':
+        final int coordinateXLeft = reader.readInt32();
+        final int coordinateYTop = reader.readInt32();
+        final int coordinateXRight = reader.readInt32();
+        final int coordinateYBottom = reader.readInt32();
+        final int maxResolution = reader.readInt32();
+        return {
+          'type': 'CropCommand',
+          'coordinateXLeft': coordinateXLeft,
+          'coordinateYTop': coordinateYTop,
+          'coordinateXRight': coordinateXRight,
+          'coordinateYBottom': coordinateYBottom,
+          'maximumBitmapResolution': maxResolution,
+        };
+      case 'ResizeCommand':
+        final int width = reader.readInt32();
+        final int height = reader.readInt32();
+        return {'type': 'ResizeCommand', 'width': width, 'height': height};
+      case 'CutCommand':
+        final position = KryoClassRegistry.readClassAndObject(reader);
+        final double width = reader.readFloat();
+        final double height = reader.readFloat();
+        final double rotation = reader.readFloat();
+        return {
+          'type': 'CutCommand',
+          'position': position,
+          'boxWidth': width,
+          'boxHeight': height,
+          'boxRotation': rotation,
+        };
+      case 'ResetCommand':
+        return {'type': 'ResetCommand'};
+      default:
+        return {'type': className};
+    }
+  }
+}

--- a/test/unit/serialization/kryo_class_registry_test.dart
+++ b/test/unit/serialization/kryo_class_registry_test.dart
@@ -1,0 +1,232 @@
+import 'dart:typed_data';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:paintroid/core/backward_compatibility/kryo_class_registry.dart';
+import 'package:paintroid/core/backward_compatibility/kryo_reader.dart';
+import 'package:paintroid/core/backward_compatibility/legacy_deserializers.dart';
+import 'package:paintroid/core/backward_compatibility/legacy_model_parser.dart';
+
+void main() {
+  group('KryoClassRegistry Tests', () {
+    test('readClassName should resolve registered class names correctly', () {
+      final bytes = Uint8List.fromList([
+        0x11,
+      ]); // ID 15 + 2 = 17 (SetDimensionCommand)
+      final reader = KryoReader(bytes);
+
+      expect(
+        KryoClassRegistry.readClassName(reader),
+        equals('SetDimensionCommand'),
+      );
+    });
+  });
+
+  group('Legacy Helper Class Deserialization', () {
+    test('deserialize Point should resolve x and y', () {
+      final bytes = Uint8List.fromList([
+        0x0A, 0x00, 0x00, 0x00, // x = 10
+        0x14, 0x00, 0x00, 0x00, // y = 20
+      ]);
+      final reader = KryoReader(bytes);
+      final point = LegacyPoint.deserialize(reader);
+
+      expect(point.x, equals(10));
+      expect(point.y, equals(20));
+    });
+
+    test('deserialize PointF should resolve float coordinates', () {
+      final bytes = Uint8List.fromList([
+        0x00, 0x00, 0xC0, 0x3F, // x = 1.5
+        0x00, 0x00, 0x20, 0x40, // y = 2.5
+      ]);
+      final reader = KryoReader(bytes);
+      final pointF = LegacyPointF.deserialize(reader);
+
+      expect(pointF.x, equals(1.5));
+      expect(pointF.y, equals(2.5));
+    });
+
+    test('deserialize RectF should resolve bounds', () {
+      final bytes = Uint8List.fromList([
+        0x00, 0x00, 0x80, 0x3F, // left = 1.0
+        0x00, 0x00, 0x00, 0x40, // top = 2.0
+        0x00, 0x00, 0x40, 0x40, // right = 3.0
+        0x00, 0x00, 0x80, 0x40, // bottom = 4.0
+      ]);
+      final reader = KryoReader(bytes);
+      final rectF = LegacyRectF.deserialize(reader);
+
+      expect(rectF.left, equals(1.0));
+      expect(rectF.top, equals(2.0));
+      expect(rectF.right, equals(3.0));
+      expect(rectF.bottom, equals(4.0));
+    });
+
+    test('deserialize Paint should read all properties', () {
+      final bytes = Uint8List.fromList([
+        0x00, 0x00, 0xFF, 0xFF, // color
+        0x00, 0x00, 0xA0, 0x40, // strokeWidth = 5.0
+        0x01, 0x00, 0x00, 0x00, // strokeCap = 1 (ROUND)
+        0x01, // isAntiAlias = true
+        0x01, 0x00, 0x00, 0x00, // style = 1 (STROKE)
+        0x01, 0x00, 0x00, 0x00, // strokeJoin = 1 (ROUND)
+        0x00, // hadFilter = false
+        0xFF, 0x00, 0x00, 0x00, // alpha = 255
+      ]);
+      final reader = KryoReader(bytes);
+      final paint = LegacyPaint.deserialize(reader);
+
+      expect(paint.strokeWidth, equals(5.0));
+      expect(paint.strokeCap, equals(1));
+      expect(paint.isAntiAlias, isTrue);
+      expect(paint.alpha, equals(255));
+    });
+
+    test('deserialize ColorHistory should read colors list', () {
+      final bytes = Uint8List.fromList([
+        0x02, 0x00, 0x00, 0x00, // size = 2
+        0xFF, 0x00, 0x00, 0x00, // color 1
+        0x00, 0x00, 0xFF, 0x00, // color 2
+      ]);
+      final reader = KryoReader(bytes);
+      final history = LegacyColorHistory.deserialize(reader);
+
+      expect(history.colors.length, equals(2));
+      expect(history.colors[0], equals(255));
+    });
+  });
+
+  group('LegacyCommandManagerModel Deserialization Tests', () {
+    test(
+      'deserialize should parse SetDimensionCommand and basic list size',
+      () {
+        final bytes = Uint8List.fromList([
+          0x11, // SetDimensionCommand class ID (15 + 2 = 17)
+          0x20, 0x03, 0x00, 0x00, // width = 800
+          0x58, 0x02, 0x00, 0x00, // height = 600
+          0x00, 0x00, 0x00, 0x00, // command list size = 0
+        ]);
+        final reader = KryoReader(bytes);
+        final model = LegacyCommandManagerModel.deserialize(reader);
+
+        expect(model.initialCommand['type'], equals('SetDimensionCommand'));
+        expect(model.initialCommand['width'], equals(800));
+        expect(model.initialCommand['height'], equals(600));
+        expect(model.commands, isEmpty);
+      },
+    );
+
+    test('deserialize should parse multiple drawing commands', () {
+      final bytes = Uint8List.fromList([
+        0x11, // SetDimensionCommand (15 + 2 = 17)
+        0x20, 0x03, 0x00, 0x00, // width = 800
+        0x58, 0x02, 0x00, 0x00, // height = 600
+        0x02, 0x00, 0x00, 0x00, // command list size = 2
+
+        0x14, // AddEmptyLayerCommand (18 + 2 = 20) -> [0x14]
+
+        0x15, // SelectLayerCommand (19 + 2 = 21) -> [0x15]
+        0x01, 0x00, 0x00, 0x00, // layerIndex = 1
+      ]);
+      final reader = KryoReader(bytes);
+      final model = LegacyCommandManagerModel.deserialize(reader);
+
+      expect(model.commands.length, equals(2));
+      expect(model.commands[0]['type'], equals('AddEmptyLayerCommand'));
+      expect(model.commands[1]['type'], equals('SelectLayerCommand'));
+      expect(model.commands[1]['layerIndex'], equals(1));
+    });
+  });
+
+  group('Legacy Path and Action Deserialization Tests', () {
+    test('deserialize Move action', () {
+      final bytes = Uint8List.fromList([
+        0x00, 0x00, 0x80, 0x3F, // x = 1.0
+        0x00, 0x00, 0x00, 0x40, // y = 2.0
+      ]);
+      final reader = KryoReader(bytes);
+      final move = LegacySerializablePathMove.deserialize(reader);
+      expect(move.x, equals(1.0));
+      expect(move.y, equals(2.0));
+    });
+
+    test('deserialize Line action', () {
+      final bytes = Uint8List.fromList([
+        0x00, 0x00, 0x00, 0x40, // x = 2.0
+        0x00, 0x00, 0x40, 0x40, // y = 3.0
+      ]);
+      final reader = KryoReader(bytes);
+      final line = LegacySerializablePathLine.deserialize(reader);
+      expect(line.x, equals(2.0));
+      expect(line.y, equals(3.0));
+    });
+
+    test('deserialize Quad action', () {
+      final bytes = Uint8List.fromList([
+        0x00, 0x00, 0x80, 0x3F, // x1 = 1.0
+        0x00, 0x00, 0x00, 0x40, // y1 = 2.0
+        0x00, 0x00, 0x40, 0x40, // x2 = 3.0
+        0x00, 0x00, 0x80, 0x40, // y2 = 4.0
+      ]);
+      final reader = KryoReader(bytes);
+      final quad = LegacySerializablePathQuad.deserialize(reader);
+      expect(quad.x1, equals(1.0));
+      expect(quad.y1, equals(2.0));
+      expect(quad.x2, equals(3.0));
+      expect(quad.y2, equals(4.0));
+    });
+
+    test('deserialize Cube action', () {
+      final bytes = Uint8List.fromList([
+        0x00, 0x00, 0x80, 0x3F, // x1 = 1.0
+        0x00, 0x00, 0x00, 0x40, // y1 = 2.0
+        0x00, 0x00, 0x40, 0x40, // x2 = 3.0
+        0x00, 0x00, 0x80, 0x40, // y2 = 4.0
+        0x00, 0x00, 0xA0, 0x40, // x3 = 5.0
+        0x00, 0x00, 0xC0, 0x40, // y3 = 6.0
+      ]);
+      final reader = KryoReader(bytes);
+      final cube = LegacySerializablePathCube.deserialize(reader);
+      expect(cube.x1, equals(1.0));
+      expect(cube.y1, equals(2.0));
+      expect(cube.x2, equals(3.0));
+      expect(cube.y2, equals(4.0));
+      expect(cube.x3, equals(5.0));
+      expect(cube.y3, equals(6.0));
+    });
+
+    test('deserialize Rewind action', () {
+      final bytes = Uint8List.fromList([]);
+      final reader = KryoReader(bytes);
+      final rewind = LegacySerializablePathRewind.deserialize(reader);
+      expect(rewind, isNotNull);
+    });
+
+    test('deserialize SerializablePath containing actions list', () {
+      final bytes = Uint8List.fromList([
+        0x02, 0x00, 0x00, 0x00, // size = 2 actions
+
+        0x25, // action 1: SerializablePathMove (35 + 2 = 37 -> 0x25)
+        0x00, 0x00, 0x80, 0x3F, // x = 1.0
+        0x00, 0x00, 0x00, 0x40, // y = 2.0
+
+        0x26, // action 2: SerializablePathLine (36 + 2 = 38 -> 0x26)
+        0x00, 0x00, 0x00, 0x40, // x = 2.0
+        0x00, 0x00, 0x40, 0x40, // y = 3.0
+      ]);
+      final reader = KryoReader(bytes);
+      final path = LegacySerializablePath.deserialize(reader);
+
+      expect(path.actions.length, equals(2));
+      expect(path.actions[0], isA<LegacySerializablePathMove>());
+      expect(path.actions[1], isA<LegacySerializablePathLine>());
+
+      final move = path.actions[0] as LegacySerializablePathMove;
+      expect(move.x, equals(1.0));
+      expect(move.y, equals(2.0));
+
+      final line = path.actions[1] as LegacySerializablePathLine;
+      expect(line.x, equals(2.0));
+      expect(line.y, equals(3.0));
+    });
+  });
+}


### PR DESCRIPTION
*This Pull Request is the second step of our 4-stage plan to add backward compatibility for legacy `.catrobat` files. It registers sequential native class IDs and reconstructs raw command models (like `CommandManagerModel` and `ColorHistory`) from the Kryo binary stream.*

[PAINTROID-761](https://catrobat.atlassian.net/browse/PAINTROID-761) 

*Note:  The comments in the code have been kept to make review of the binary format easier, and they will be removed once the PR has been reviewed.*

## New Features and Enhancements
- **Sequential Native Class Registration (`KryoClassRegistry`)**: Mapped sequential native Paintroid class IDs (from ID 9 to 55) in Dart, resolving registered classes and dynamic references on the wire with proper Kryo ID offsets.
- **Custom Deserializers for Legacy Helper Structures**: Added custom binary deserializers under `lib/core/backward_compatibility/legacy_deserializers.dart` to decode standard helper structures (`Paint`, `ColorHistory`, `Point`, `PointF`, `RectF`, `FloatArray`, `StringArray`).
- **Path Action Deserialization (`SerializablePath`)**: Implemented dynamic deserialization for legacy `SerializablePath` and all its individual path actions (`Move`, `Line`, `Quad`, `Cube`, and `Rewind`).
- **Legacy Command Model Parsing (`LegacyCommandManagerModel`)**: Completed raw deserialization of the root `CommandManagerModel` structure, including decoding for all 14 legacy command types (such as `SetDimensionCommand`, `PathCommand`, layer state operations, flip/rotate/crop/resize commands).
- **Comprehensive Registry & Parser Unit Testing**: Added a complete suite of unit tests under `test/unit/serialization/kryo_class_registry_test.dart` to verify the exact reconstruction of all custom objects and command sequences. All tests are passing locally.
- **Isolated Implementation**: Maintained strict directory separation under `lib/core/backward_compatibility/`, ensuring zero impact on the existing codebase during review.

---

### Backward Compatibility Roadmap
To make this feature easy to review and track, the work is organized into four sequential stages:
1. **Stage 1 (Completed - Foundational Binary Reader)**: The low-level `KryoReader` to parse bytes into basic Dart datatypes (ints, strings, doubles).
2. **Stage 2 (This PR - Registry & Model Parser)**: Setting up the class registry matching the native app's sequential registration IDs to reconstruct raw objects (like `CommandManagerModel` and `ColorHistory`).
3. **Stage 3 (Command Transformation)**: Converting those legacy Android commands (such as historical lines, shapes, and layer state changes) into their equivalent Flutter drawing commands.
4. **Stage 4 (UI Performance & Fallbacks)**: Running the decoding logic on background isolates to keep the UI smooth during large file loads, and adding fallback renderers for legacy tools not yet supported by Flutter.

## Refactorings and Bug Fixes
- None (New feature foundation).

## Checklist

#### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Add the link to the ticket in Jira in the description of the PR
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines (Wiki)
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Add new information to the [Wiki](https://github.com/Catrobat/Paintroid-Flutter/wiki)


[PAINTROID-761]: https://catrobat.atlassian.net/browse/PAINTROID-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ==
