### PR TITLE
PAINTROID-723: Fix CircularProgressIndicator animation on landing page

### DIFF
--- a/lib/ui/pages/landing_page/landing_page.dart
+++ b/lib/ui/pages/landing_page/landing_page.dart
@@ -39,6 +39,8 @@ class _LandingPageState extends ConsumerState<LandingPage> {
   late ProjectDatabase database;
   late IFileService fileService;
   late IImageService imageService;
+  Future<List<Project>>? _projectsFuture;
+  ProjectDatabase? _projectsLoadedFrom;
 
   @override
   void initState() {
@@ -96,9 +98,15 @@ class _LandingPageState extends ConsumerState<LandingPage> {
     return database.projectDAO.getProjects();
   }
 
+  void _refreshProjectsFuture() {
+    _projectsFuture = _getProjects();
+  }
+
   Future<void> _navigateToPocketPaint() async {
     await Navigator.pushNamed(context, '/PocketPaint');
-     if (mounted){setState(() {});}
+    if (mounted) {
+      setState(_refreshProjectsFuture);
+    }
   }
 
   Future<bool> _loadProject(IOHandler ioHandler, Project project) async {
@@ -141,7 +149,13 @@ class _LandingPageState extends ConsumerState<LandingPage> {
 
     final db = ref.watch(ProjectDatabase.provider);
     db.when(
-      data: (value) => database = value,
+      data: (value) {
+        database = value;
+        if (!identical(_projectsLoadedFrom, value)) {
+          _projectsLoadedFrom = value;
+          _refreshProjectsFuture();
+        }
+      },
       error: (err, stacktrace) =>
           ToastUtils.showShortToast(message: 'Error: $err'),
       loading: () {},
@@ -158,7 +172,7 @@ class _LandingPageState extends ConsumerState<LandingPage> {
         actions: const [MainOverflowMenu()],
       ),
       body: FutureBuilder(
-        future: _getProjects(),
+        future: _projectsFuture,
         builder: (BuildContext context, AsyncSnapshot<List<Project>> snapshot) {
           if (snapshot.connectionState == ConnectionState.done &&
               snapshot.hasData) {

--- a/test/widget/landing_page/landing_page_test.dart
+++ b/test/widget/landing_page/landing_page_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:ui' as ui;
 
@@ -736,6 +737,30 @@ void main() {
       await tester.pump();
 
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'Should reuse the projects future across rebuilds while the list is loading',
+    (tester) async {
+      final projectsCompleter = Completer<List<Project>>();
+      when(database.projectDAO).thenReturn(dao);
+      when(dao.getProjects()).thenAnswer((_) => projectsCompleter.future);
+
+      await tester.pumpWidget(sut);
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsWidgets);
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 16));
+
+      expect(find.byType(CircularProgressIndicator), findsWidgets);
+
+      projectsCompleter.complete([]);
+      await tester.pumpAndSettle();
+
+      verify(dao.getProjects()).called(1);
     },
   );
 }


### PR DESCRIPTION
Ticket: https://catrobat.atlassian.net/browse/PAINTROID-723

## New Features and Enhancements
- None

## Refactorings and Bug Fixes
- Landing page passed a new `_getProjects()` future into `FutureBuilder` on every rebuild, which restarted `CircularProgressIndicator` and made the spinner look stuck / non-animated.
- Cache the projects `Future` on State; recreate it when returning from Pocket Paint and when `ProjectDatabase` is replaced after invalidate (delete/rename).
- Widget test: while the list future is pending, rebuilds do not call `getProjects()` again.

## Checklist

#### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Add the link to the ticket in Jira in the description of the PR
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines (Wiki)
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Add new information to the [Wiki](https://github.com/Catrobat/Paintroid-Flutter/wiki)

### Verification
- `flutter test test/widget/landing_page/landing_page_test.dart` — 21/21 passed
- Physical device / emulator animation smoke not run here